### PR TITLE
fix(tc6-regs): defer extended-status read via CheckTimers

### DIFF
--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -102,6 +102,7 @@ typedef struct
     uint8_t burstTimer;
     uint8_t chipRev;
     bool extBlock;
+    bool extStatusPending;
     bool initialized;
     bool initBusy;
     bool initDone;
@@ -172,6 +173,9 @@ void TC6Regs_CheckTimers(void)
             pReg->unlockExtTime = 0;
             TC6_UnlockExtendedStatus(pReg->pTC6);
         }
+        if (pReg->extStatusPending && TC6_ReadRegister(pReg->pTC6, 0x00000008, CONTROL_PROTECTION, OnStatus0, NULL)) {
+            pReg->extStatusPending = false;
+        }
         DoInitialization(pReg);
 
         if (pReg->plcaChanged) {
@@ -238,8 +242,8 @@ void TC6_CB_OnExtendedStatus(TC6_t *pInst, void *pGlobalTag)
    (void)pGlobalTag;
     TC6Reg_t *pReg = GetContext(pInst);
     pReg->unlockExtTime = TC6Regs_CB_GetTicksMs();
-    while (!TC6_ReadRegister(pInst, 0x00000008, CONTROL_PROTECTION, OnStatus0, NULL)) {
-        TC6_Service(pInst, true);
+    if (!TC6_ReadRegister(pInst, 0x00000008, CONTROL_PROTECTION, OnStatus0, NULL)) {
+        pReg->extStatusPending = true;
     }
 }
 


### PR DESCRIPTION
fix(tc6-regs): defer extended-status read via CheckTimers