### PR TITLE
chore(tc6): fix REGISTER_OP_INVALLID typo

### DIFF
--- a/libtc6/src/tc6-queue.h
+++ b/libtc6/src/tc6-queue.h
@@ -55,7 +55,7 @@ struct qspibuf {
 
 enum register_op_type
 {
-    REGISTER_OP_INVALLID,
+    REGISTER_OP_INVALID,
     REGISTER_OP_WRITE,
     REGISTER_OP_READ,
     REGISTER_OP_READWRITE_STAGE1,

--- a/libtc6/src/tc6.c
+++ b/libtc6/src/tc6.c
@@ -793,7 +793,7 @@ static bool accessRegisters(TC6_t *g, enum register_op_type op, uint32_t addr, u
     bool write = true;
     bool success = false;
     TC6_ASSERT(g && (TC6_MAGIC == g->magic));
-    TC6_ASSERT(REGISTER_OP_INVALLID != op);
+    TC6_ASSERT(REGISTER_OP_INVALID != op);
     if (regop_stage1_enqueue_ready(&g->regop_q)) {
         success = true;
         switch(op) {
@@ -809,7 +809,7 @@ static bool accessRegisters(TC6_t *g, enum register_op_type op, uint32_t addr, u
         case REGISTER_OP_READWRITE_STAGE2:
             write = true;
             break;
-        case REGISTER_OP_INVALLID:
+        case REGISTER_OP_INVALID:
         default:
             TC6_ASSERT(false);
             success = false;


### PR DESCRIPTION
chore(tc6): fix REGISTER_OP_INVALLID typo

tc6-queue.h is generated; the .conf source should also be updated
upstream so regeneration does not revert this rename.