### PR TITLE
chore(tc6): static-assert enum/string-table lengths match

### DIFF
--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -89,6 +89,8 @@ static const char* TC6_events[] = {
     "Unsupported_Hardware",
 };
 
+typedef char tc6_events_length_matches_enum[((sizeof(TC6_events) / sizeof(TC6_events[0])) == TC6Regs_Event_Last) ? 1 : -1];
+
 typedef struct
 {
     uint8_t mac[6];

--- a/libtc6/src/tc6.c
+++ b/libtc6/src/tc6.c
@@ -131,6 +131,8 @@ static const char* TC6_Errors[] = {
     "Plca_Status_Fail"                  /** PLCA status check failure */
 };
 
+typedef char tc6_errors_length_matches_enum[((sizeof(TC6_Errors) / sizeof(TC6_Errors[0])) == TC6Error_Last) ? 1 : -1];
+
 static const uint8_t MASK[9] = { 0x00u, 0x01u, 0x03u, 0x07u, 0x0Fu, 0x1Fu, 0x3Fu, 0x7Fu, 0xFFu };
 
 typedef enum


### PR DESCRIPTION
chore(tc6): static-assert enum/string-table lengths match