### PR TITLE
Document Init functions as non-reentrant (sync-branch)

### DIFF
--- a/libtc6/inc/tc6-regs.h
+++ b/libtc6/inc/tc6-regs.h
@@ -88,6 +88,7 @@ typedef enum
 
 /** \brief Initializes the LAN865x with its default register settings
  *  \note Must be called before any other functions of this component.
+ *  \warning Not reentrant. Must not be called from multiple threads concurrently.
  *  \param pInst - The pointer returned by TC6_Init.
  *  \param pTag - This pointer will be returned back with any callback of this component. Maybe set to NULL.
  *  \param mac - The 6 Byte public visible MAC address of the TC6 MAC.

--- a/libtc6/inc/tc6.h
+++ b/libtc6/inc/tc6.h
@@ -104,6 +104,7 @@ typedef struct {
 /** \brief Initializes the lwIP Interface Driver for TC6.
  *  \param pGlobalTag - This pointer will be returned back with any callback of this component. Maybe set to NULL.
  *  \note Must be called before any other functions of this component.
+ *  \warning Not reentrant. Must not be called from multiple threads concurrently.
  *  \return Filled structure for further usage with other functions of this component. Or NULL, if there was an error.
  */
 TC6_t *TC6_Init(void *pGlobalTag);


### PR DESCRIPTION
Part of the code review against the `no-queues-synchronous` branch.

Built cleanly against `examples/lwIP-SAM-E54-Curiosity/libtc6.X` with XC32 v4.60.