### PR TITLE
Document TC6_CB_OnError as ISR-reachable (sync-branch)

### DIFF
--- a/libtc6/inc/tc6.h
+++ b/libtc6/inc/tc6.h
@@ -250,6 +250,7 @@ extern void TC6_CB_OnRxEthernetPacket(TC6_t *pInst, bool success, uint16_t len, 
 /**
  * \brief Callback when ever an error occurred.
  * \note This function must be implemented by the integrator.
+ * \note May be invoked from interrupt context via TC6_HandleMacPhyInterrupt(). Integrator must keep the handler ISR-safe or defer work.
  * \param pInst - The pointer returned by TC6_Init.
  * \param err - Enumeration value holding the actual error condition.
  * \param pGlobalTag - The exact same pointer, which was given along with the TC6_Init() function.


### PR DESCRIPTION
Part of the code review against the `no-queues-synchronous` branch.

Built cleanly against `examples/lwIP-SAM-E54-Curiosity/libtc6.X` with XC32 v4.60.