### PR TITLE
Guard DoInitialization against unbound MAC-PHY slots (sync-branch)

### DIFF
--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -331,7 +331,7 @@ static void DoInitialization(TC6Reg_t *pReg)
     uint32_t value = 0;
     uint32_t regVal;
 
-    if ((NULL != pReg) && !pReg->initialized) {
+    if ((NULL != pReg) && (NULL != pReg->pTC6) && !pReg->initialized) {
         pReg->initialized = true;
         TC6_Reset(pReg->pTC6);
         /* Perform Soft Reset with unprotected call */


### PR DESCRIPTION
Part of the code review against the `no-queues-synchronous` branch.

Built cleanly against `examples/lwIP-SAM-E54-Curiosity/libtc6.X` with XC32 v4.60.