### PR TITLE
Guard TC6Regs_GetChipRevision against NULL context (sync-branch)

### DIFF
--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -161,8 +161,12 @@ bool TC6Regs_SetPlca(TC6_t *pTC6, bool plcaEnable, uint8_t nodeId, uint8_t nodeC
 
 uint8_t TC6Regs_GetChipRevision(TC6_t *pTC6)
 {
+    uint8_t chipRev = 0u;
     TC6Reg_t *pReg = GetContext(pTC6);
-    return pReg->chipRev;
+    if (NULL != pReg) {
+        chipRev = pReg->chipRev;
+    }
+    return chipRev;
 }
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/


### PR DESCRIPTION
Part of the code review against the `no-queues-synchronous` branch.

Built cleanly against `examples/lwIP-SAM-E54-Curiosity/libtc6.X` with XC32 v4.60.