### PR TITLE
Only flip MAC-PHY online when init actually succeeded (sync-branch)

### DIFF
--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -410,8 +410,10 @@ static void DoInitialization(TC6Reg_t *pReg)
         while (!TC6_WriteRegister(pReg->pTC6, 0x00010000 /* NETWORK_CONTROL */, 0xCu, CONTROL_PROTECTION)) {
             /* Retry */
         }
-        TC6_EnableData(pReg->pTC6, true);
-        pReg->initDone = true;
+        if (pReg->initialized) {
+            TC6_EnableData(pReg->pTC6, true);
+            pReg->initDone = true;
+        }
     }
 }
 


### PR DESCRIPTION
Part of the code review against the `no-queues-synchronous` branch.

Built cleanly against `examples/lwIP-SAM-E54-Curiosity/libtc6.X` with XC32 v4.60.