### PR TITLE
Guard RTSA timestamp extraction against short slice (sync-branch)

### DIFF
--- a/libtc6/src/tc6.c
+++ b/libtc6/src/tc6.c
@@ -482,7 +482,7 @@ static void on_rx_slice(TC6_t *g, const uint8_t *pBuf, uint16_t offset, uint16_t
 
     /* handle timestamp (RTSA) */
     /* ToDo: get timestamp according to selected timestamp length (32bit or 64bit) */
-    if (rtsa) {
+    if (rtsa && (buf_len >= 8u)) {
         g->ts = ((uint64_t)buff[0] << 56) |
                 ((uint64_t)buff[1] << 48) |
                 ((uint64_t)buff[2] << 40) |


### PR DESCRIPTION
Part of the code review against the `no-queues-synchronous` branch.

Built cleanly against `examples/lwIP-SAM-E54-Curiosity/libtc6.X` with XC32 v4.60.