### PR TITLE
tc6: fix implicit widening in pointer arithmetic (sync branch)

### DIFF
--- a/libtc6/src/tc6.c
+++ b/libtc6/src/tc6.c
@@ -1050,7 +1050,7 @@ static uint16_t mk_ctrl_req(bool wnr, bool aid, uint32_t addr,
             uint8_t *dst = tx_buf;
             uint16_t i;
 
-            dst = &dst[num_regs * 4u];
+            dst = &dst[(size_t)num_regs * 4u];
             for (i = num_regs; i > 0u; i--) {
                 uint32_t v = regs[i - 1u];
 
@@ -1091,7 +1091,7 @@ static uint16_t mk_secure_ctrl_req(bool wnr, bool aid, uint32_t addr,
             uint16_t i;
             uint8_t *dst = tx_buf;
 
-            dst = &dst[num_regs * 8u];
+            dst = &dst[(size_t)num_regs * 8u];
             for (i = num_regs; i > 0u; i--) {
                 uint32_t v = regs[i - 1u];
 


### PR DESCRIPTION
## Summary

Fixes 2 clang-tidy `bugprone-implicit-widening-of-multiplication-result` warnings in register buffer pointer arithmetic.

## Problem

Multiplication of `uint16_t num_regs` with unsigned constants (`4u`, `8u`) results in `unsigned int`. When used as array offset in `&dst[num_regs * 4u]`, the result is implicitly widened to `size_t`, triggering implicit-widening warnings.

## Solution

Cast `num_regs` to `size_t` before multiplication: `(size_t)num_regs * 4u`. Explicit cast clarifies the type promotion and silences the warning.

## Verification

Affected functions: `mk_ctrl_req` and `mk_secure_ctrl_req`. Register arrays are 32-bit fields; `num_regs * 4/8` fits safely in `size_t`. No behavior change.

Closes findings from static-analysis scan.