### PR TITLE
tc6-regs: fix narrowing conversions in init

### DIFF
--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -588,10 +588,10 @@ static void InitChip(TC6_t *pInst)
 
     /* CONFIG PARAMETER 3 */
     cfgParam = initValue3 & 0x000Fu;
-    tempParam = (int16_t)9 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)9 + (int16_t)initOffset1; /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 10;
 
-    tempParam = (int16_t)14 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)14 + (int16_t)initOffset1; /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 4;
 
     while (pReg->initialized && !TC6_WriteRegister(pReg->pTC6, 0x00040084, cfgParam, CONTROL_PROTECTION, NULL, NULL)) {
@@ -600,7 +600,7 @@ static void InitChip(TC6_t *pInst)
 
     /* CONFIG PARAMETER 4 */
     cfgParam = initValue4 & 0x3FFu;
-    tempParam = (int16_t)40 + initOffset2; /* To be MISRA compliant */
+    tempParam = (int16_t)40 + (int16_t)initOffset2; /* To be MISRA compliant */
     cfgParam |= (uint16_t)(tempParam) << 10;
 
     while (pReg->initialized && !TC6_WriteRegister(pReg->pTC6, 0x0004008A, cfgParam, CONTROL_PROTECTION, NULL, NULL)) {
@@ -609,10 +609,10 @@ static void InitChip(TC6_t *pInst)
 
     /* CONFIG PARAMETER 5 */
     cfgParam = initValue5 & 0xC0C0u;
-    tempParam = (int16_t)5 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)5 + (int16_t)initOffset1; /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 8;
 
-    tempParam = (int16_t)9 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)9 + (int16_t)initOffset1; /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam;
 
     while (pReg->initialized && !TC6_WriteRegister(pReg->pTC6, 0x000400AD, cfgParam, CONTROL_PROTECTION, NULL, NULL)) {
@@ -621,10 +621,10 @@ static void InitChip(TC6_t *pInst)
 
     /* CONFIG PARAMETER 6 */
     cfgParam = initValue6 & 0xC0C0u;
-    tempParam = (int16_t)9 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)9 + (int16_t)initOffset1; /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 8;
 
-    tempParam = (int16_t)14 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)14 + (int16_t)initOffset1; /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam;
 
     while (pReg->initialized && !TC6_WriteRegister(pReg->pTC6, 0x000400AE, cfgParam, CONTROL_PROTECTION, NULL, NULL)) {
@@ -634,10 +634,10 @@ static void InitChip(TC6_t *pInst)
     /* CONFIG PARAMETER 7 */
     cfgParam = initValue7 & 0xC0C0u;
 
-    tempParam = (int16_t)17 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)17 + (int16_t)initOffset1; /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 8;
 
-    tempParam = (int16_t)22 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)22 + (int16_t)initOffset1; /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam;
 
     while (pReg->initialized && !TC6_WriteRegister(pReg->pTC6, 0x000400AF, cfgParam, CONTROL_PROTECTION, NULL, NULL)) {


### PR DESCRIPTION
## Summary
Cast initOffset operands to int16_t before arithmetic in config parameter initialization. Fixes 8 clang-tidy bugprone-narrowing-conversions warnings.

## Test plan
- Static analysis re-run confirms warnings eliminated
- Code logic unchanged (only explicit casts added)