### PR TITLE
tc6: merge consecutive identical switch cases

### DIFF
--- a/libtc6/src/tc6.c
+++ b/libtc6/src/tc6.c
@@ -830,8 +830,6 @@ static bool accessRegisters(TC6_t *g, enum register_op_type op, uint32_t addr, u
             write = true;
             break;
         case REGISTER_OP_READ:
-            write = false;
-            break;
         case REGISTER_OP_READWRITE_STAGE1:
             write = false;
             break;


### PR DESCRIPTION
## Summary
Merge REGISTER_OP_READ and REGISTER_OP_READWRITE_STAGE1 cases which both set write = false. Reduces code duplication in switch statement. Fixes clang-tidy bugprone-branch-clone warning.

## Test plan
- Static analysis re-run confirms warning eliminated
- Code logic unchanged (only case fall-through added)