### PR TITLE
Allow configuration of alignment of SPI buffers

### DIFF
--- a/libtc6/cfg-example/tc6-conf.h
+++ b/libtc6/cfg-example/tc6-conf.h
@@ -153,4 +153,16 @@ extern "C" {
 #define CONTROL_PROTECTION  (true)
 #endif
 
+/**
+ * \brief Controls the alignment in bytes for the SPI buffers.
+ * \note On some architectures, like the Cortex M7 which has a L1 data cache, the SPI buffers must be 32-byte aligned for DMA transfers
+ *       and cache invalidation to work properly. Define TC6_SPI_BUF_ALIGNMENT and set the correct TC6_SPI_BUF_ALIGNMENT_SIZE to handle
+ *       this here.
+ */
+#ifndef TC6_SPI_BUF_ALIGNMENT_SIZE
+#ifdef TC6_SPI_BUF_ALIGNMENT
+#define TC6_SPI_BUF_ALIGNMENT_SIZE (32u)
+#endif
+#endif
+
 #endif /* TC6_CONFIG_H_ */

--- a/libtc6/src/tc6-queue.h
+++ b/libtc6/src/tc6-queue.h
@@ -35,6 +35,18 @@ Microchip or any third party.
 #include <stdbool.h>
 #include "tc6-conf.h"
 
+#ifdef TC6_SPI_BUF_ALIGNMENT
+    #if defined(__GNUC__) || defined(__clang__)
+        #define SPI_BUF_ALIGNMENT __attribute__((aligned(TC6_SPI_BUF_ALIGNMENT_SIZE)))
+    #elif defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
+        #define SPI_BUF_ALIGNMENT __attribute__((aligned(TC6_SPI_BUF_ALIGNMENT_SIZE)))
+    #else
+        #define SPI_BUF_ALIGNMENT
+    #endif
+#else
+    #define SPI_BUF_ALIGNMENT
+#endif
+
 struct qtxeth {
     void *priv;
     TC6_RawTxCallback_t txCallback;
@@ -47,9 +59,18 @@ struct qtxeth {
 #define TC6_CNTRL_BUF_SIZE  ((2u + (TC6_MAX_CNTRL_VARS * 2u)) * 4u)
 #define TC6_SPI_BUF_SIZE    (TC6_CHUNKS_XACT * TC6_CHUNK_BUF_SIZE)
 
+// Adhere to specific SPI buffer alignment requirements if defined in tc6-conf.h
+#ifdef TC6_SPI_BUF_ALIGNMENT
+#define TC6_CNTRL_BUF_SIZE_ALIGNED  (((TC6_CNTRL_BUF_SIZE + (TC6_SPI_BUF_ALIGNMENT_SIZE - 1)) / TC6_SPI_BUF_ALIGNMENT_SIZE) * TC6_SPI_BUF_ALIGNMENT_SIZE)
+#define TC6_SPI_BUF_SIZE_ALIGNED    (((TC6_SPI_BUF_SIZE   + (TC6_SPI_BUF_ALIGNMENT_SIZE - 1)) / TC6_SPI_BUF_ALIGNMENT_SIZE) * TC6_SPI_BUF_ALIGNMENT_SIZE)
+#else
+#define TC6_CNTRL_BUF_SIZE_ALIGNED  (TC6_CNTRL_BUF_SIZE)
+#define TC6_SPI_BUF_SIZE_ALIGNED    (TC6_SPI_BUF_SIZE)
+#endif
+
 struct qspibuf {
-    uint8_t txBuff[TC6_SPI_BUF_SIZE];
-    uint8_t rxBuff[TC6_SPI_BUF_SIZE];
+    uint8_t txBuff[TC6_SPI_BUF_SIZE_ALIGNED] SPI_BUF_ALIGNMENT;
+    uint8_t rxBuff[TC6_SPI_BUF_SIZE_ALIGNED] SPI_BUF_ALIGNMENT;
     uint16_t length;
 };
 
@@ -63,8 +84,8 @@ enum register_op_type
 };
 
 struct register_operation {
-    uint8_t tx_buf[TC6_CNTRL_BUF_SIZE];
-    uint8_t rx_buf[TC6_CNTRL_BUF_SIZE];
+    uint8_t tx_buf[TC6_CNTRL_BUF_SIZE_ALIGNED] SPI_BUF_ALIGNMENT;
+    uint8_t rx_buf[TC6_CNTRL_BUF_SIZE_ALIGNED] SPI_BUF_ALIGNMENT;
     TC6_RegCallback_t callback;
     void *tag;
     enum register_op_type op;

--- a/libtc6/src/tc6.c
+++ b/libtc6/src/tc6.c
@@ -188,6 +188,24 @@ struct TC6_t
 };
 
 static struct TC6_t m_tc6[TC6_MAX_INSTANCES];
+
+#ifdef TC6_SPI_BUF_ALIGNMENT
+    #if defined(__GNUC__) || defined(__clang__)
+        #define ALIGNOF_VAR(var) _Alignof(var)
+    #elif defined(__ICCARM__) || defined(__IAR_SYSTEMS_ICC__)
+        #define ALIGNOF_VAR(var) __alignof__(var)
+    #else
+        #define ALIGNOF_VAR(var)
+    #endif
+
+    TC6_STATIC_ASSERT((ALIGNOF_VAR(m_tc6[0].spiBuf[0].txBuff) == TC6_SPI_BUF_ALIGNMENT_SIZE), txBuff_must_be_aligned);
+    TC6_STATIC_ASSERT((ALIGNOF_VAR(m_tc6[0].spiBuf[0].rxBuff) == TC6_SPI_BUF_ALIGNMENT_SIZE), rxBuff_must_be_aligned);
+    TC6_STATIC_ASSERT((ALIGNOF_VAR(m_tc6[0].regop_storage[0].tx_buf) == TC6_SPI_BUF_ALIGNMENT_SIZE), tx_buff_must_be_aligned);
+    TC6_STATIC_ASSERT((ALIGNOF_VAR(m_tc6[0].regop_storage[0].rx_buf) == TC6_SPI_BUF_ALIGNMENT_SIZE), rx_buff_must_be_aligned);
+    TC6_STATIC_ASSERT((offsetof(struct qspibuf, length) % TC6_SPI_BUF_ALIGNMENT_SIZE == 0), qspibuf_length_must_be_aligned);
+    TC6_STATIC_ASSERT((offsetof(struct register_operation, callback) % TC6_SPI_BUF_ALIGNMENT_SIZE == 0), register_operation_callback_must_be_aligned);
+#endif
+
 static volatile bool m_tc6Valid[TC6_MAX_INSTANCES] = { 0 };
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/


### PR DESCRIPTION
Allow configuration of alignment of SPI buffers for architectures like the Cortex M7 which require strictly aligned buffers for correct DMA SPI operations and L1 data cache handling.

