### PR TITLE
Add .github/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 **/nbproject/Package-*
 **/nbproject/project.properties
 
+# GitHub config
+.github/
+
 # Claude Code
 .claude/
 .claude-code/


### PR DESCRIPTION
Exclude the `.github/` directory from version control (e.g. local Copilot instructions, workflow drafts).