### PR TITLE
Harden SPI retry loops and fix extended-status dispatch

### DIFF
--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -68,7 +68,6 @@ typedef struct
     uint8_t burstCount;
     uint8_t burstTimer;
     uint8_t chipRev;
-    bool extBlock;
     bool initialized;
     bool initDone;
     bool enablePlca;
@@ -122,6 +121,9 @@ void TC6Regs_CheckTimers(void)
     /* Find existing entry */
     for (i = 0u; i < TC6_MAX_INSTANCES; i++) {
         TC6Reg_t *pReg = &m_reg[i];
+        if (NULL == pReg->pTC6) {
+            continue;
+        }
         if ((0u != pReg->unlockExtTime) && ((TC6Regs_CB_GetTicksMs() - pReg->unlockExtTime) >= DELAY_UNLOCK_EXT)) {
             pReg->unlockExtTime = 0;
             TC6_UnlockExtendedStatus(pReg->pTC6);
@@ -186,12 +188,21 @@ void TC6_CB_OnExtendedStatus(TC6_t *pInst, void *pGlobalTag)
 {
    (void)pGlobalTag;
     TC6Reg_t *pReg = GetContext(pInst);
-    uint32_t value = 0u;
+    if (NULL == pReg) {
+        return;
+    }
+    uint32_t value0 = 0u;
+    uint32_t value1 = 0u;
     uint8_t i;
+    bool extBlock = false;
     pReg->unlockExtTime = TC6Regs_CB_GetTicksMs();
-    (void)RetryRead(pInst, 0x00000008, &value, TC6_REGS_CONTROL_PROTECTION);
+
+    /* Always read both Status0 and Status1 — they may both have bits set simultaneously. */
+    (void)RetryRead(pInst, 0x00000008, &value0, TC6_REGS_CONTROL_PROTECTION);
+    (void)RetryRead(pInst, 0x00000009, &value1, TC6_REGS_CONTROL_PROTECTION);
+
     for (i = 0u; i < 32u; i++) {
-        if (0u != (value & (1u << i))) {
+        if (0u != (value0 & (1u << i))) {
             switch (i) {
                 case 0:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_Transmit_Protocol_Error, pReg->pTag); break;
                 case 1:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_Transmit_Buffer_Overflow_Error, pReg->pTag); break;
@@ -210,55 +221,55 @@ void TC6_CB_OnExtendedStatus(TC6_t *pInst, void *pGlobalTag)
             }
         }
     }
-    if (0u == value) {
-        (void)RetryRead(pInst, 0x00000009, &value, TC6_REGS_CONTROL_PROTECTION);
-        bool extBlock = false;
+    if (0u != value0) {
+        /* Write to clear pending flags */
+        (void)RetryWrite(pInst, 0x00000008, value0, TC6_REGS_CONTROL_PROTECTION);
+    }
+
+    for (i = 0u; i < 32u; i++) {
+        if (0u != (value1 & (1u << i))) {
+            switch (i) {
+                case 0:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_RX_Non_Recoverable_Error, pReg->pTag); break;
+                case 1:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Non_Recoverable_Error, pReg->pTag); break;
+                case 17: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_FSM_State_Error, pReg->pTag); break;
+                case 18: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_SRAM_ECC_Error, pReg->pTag); break;
+                case 19: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_Undervoltage, pReg->pTag); break;
+                case 20: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_Internal_Bus_Error, pReg->pTag); break;
+                case 21: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Overflow_A, pReg->pTag); break;
+                case 22: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Overflow_B, pReg->pTag); break;
+                case 23: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Overflow_C, pReg->pTag); break;
+                case 24: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Missed_A, pReg->pTag); break;
+                case 25: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Missed_B, pReg->pTag); break;
+                case 26: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Missed_C, pReg->pTag); break;
+                case 27: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_MCLK_GEN_Status, pReg->pTag); break;
+                case 28: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_gPTP_PA_TS_EG_Status, pReg->pTag); break;
+                case 29: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_Extended_Block_Status, pReg->pTag);
+                    extBlock = true;
+                    break;
+                default: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_UnknownError, pReg->pTag); break;
+            }
+        }
+    }
+    if (0u != value1) {
+        /* Write to clear pending flags */
+        (void)RetryWrite(pInst, 0x00000009, value1, TC6_REGS_CONTROL_PROTECTION);
+    }
+
+    if (extBlock) {
+        uint32_t valueExt = 0u;
+        (void)RetryRead(pInst, 0x000A0087, &valueExt, TC6_REGS_CONTROL_PROTECTION);
         for (i = 0u; i < 32u; i++) {
-            if (0u != (value & (1u << i))) {
+            if (0u != (valueExt & (1u << i))) {
                 switch (i) {
-                    case 0:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_RX_Non_Recoverable_Error, pReg->pTag); break;
-                    case 1:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Non_Recoverable_Error, pReg->pTag); break;
-                    case 17: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_FSM_State_Error, pReg->pTag); break;
-                    case 18: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_SRAM_ECC_Error, pReg->pTag); break;
-                    case 19: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_Undervoltage, pReg->pTag); break;
-                    case 20: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_Internal_Bus_Error, pReg->pTag); break;
-                    case 21: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Overflow_A, pReg->pTag); break;
-                    case 22: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Overflow_B, pReg->pTag); break;
-                    case 23: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Overflow_C, pReg->pTag); break;
-                    case 24: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Missed_A, pReg->pTag); break;
-                    case 25: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Missed_B, pReg->pTag); break;
-                    case 26: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_TX_Timestamp_Capture_Missed_C, pReg->pTag); break;
-                    case 27: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_MCLK_GEN_Status, pReg->pTag); break;
-                    case 28: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_gPTP_PA_TS_EG_Status, pReg->pTag); break;
-                    case 29: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_Extended_Block_Status, pReg->pTag);
-                        extBlock = true;
-                        break;
+                    case 0:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_SPI_Err_Int, pReg->pTag); break;
+                    case 1:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_MAC_BMGR_Int, pReg->pTag); break;
+                    case 2:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_MAC_Int, pReg->pTag); break;
+                    case 3:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_HMX_Int, pReg->pTag); break;
+                    case 31: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_GINT_Mask, pReg->pTag); break;
                     default: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_UnknownError, pReg->pTag); break;
                 }
             }
         }
-        if (0u != value) {
-            /* Write to clear pending flags */
-            (void)RetryWrite(pInst, 0x00000009, value, TC6_REGS_CONTROL_PROTECTION);
-        }
-        if (extBlock) {
-            (void)RetryRead(pInst, 0x000A0087, &value, TC6_REGS_CONTROL_PROTECTION);
-            for (i = 0u; i < 32u; i++) {
-                if (0u != (value & (1u << i))) {
-                    switch (i) {
-                        case 0:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_SPI_Err_Int, pReg->pTag); break;
-                        case 1:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_MAC_BMGR_Int, pReg->pTag); break;
-                        case 2:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_MAC_Int, pReg->pTag); break;
-                        case 3:  TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_HMX_Int, pReg->pTag); break;
-                        case 31: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_GINT_Mask, pReg->pTag); break;
-                        default: TC6Regs_CB_OnEvent(pInst, TC6Regs_Event_UnknownError, pReg->pTag); break;
-                    }
-                }
-            }
-        }
-    } else {
-        /* Write to clear pending flags */
-        (void)RetryWrite(pInst, 0x00000008, value, TC6_REGS_CONTROL_PROTECTION);
     }
 }
 
@@ -459,13 +470,20 @@ static bool ReadIndirectReg(TC6_t *pInst, uint32_t addr, uint32_t *pVal, uint32_
 {
     uint32_t regVal = (addr & 0x000Fu);
     uint32_t value = 0u;
-    (void)RetryWrite(pInst, 0x000400D8, regVal, TC6_REGS_CONTROL_PROTECTION);
-    (void)RetryWrite(pInst, 0x000400DA, 0x0002, TC6_REGS_CONTROL_PROTECTION);
-    (void)RetryRead(pInst, 0x000400D9, &value, TC6_REGS_CONTROL_PROTECTION);
-    if (NULL != pVal) {
+    bool success = true;
+    if (!RetryWrite(pInst, 0x000400D8, regVal, TC6_REGS_CONTROL_PROTECTION)) {
+        success = false;
+    }
+    if (success && !RetryWrite(pInst, 0x000400DA, 0x0002, TC6_REGS_CONTROL_PROTECTION)) {
+        success = false;
+    }
+    if (success && !RetryRead(pInst, 0x000400D9, &value, TC6_REGS_CONTROL_PROTECTION)) {
+        success = false;
+    }
+    if (success && (NULL != pVal)) {
         *pVal = (value & mask);
     }
-    return true;
+    return success;
 }
 
 static int8_t GetSignedVal(uint32_t val)
@@ -510,19 +528,19 @@ static void InitChip(TC6_t *pInst)
     if (pReg->initialized && ReadIndirectReg(pInst, 0x8, &val, 0x1F)) {
         initOffset2 = GetSignedVal(val);
     }
-    if (pReg->initialized && TC6_ReadRegister(pInst, 0x00040084, &val, TC6_REGS_CONTROL_PROTECTION)) {
+    if (pReg->initialized && RetryRead(pInst, 0x00040084, &val, TC6_REGS_CONTROL_PROTECTION)) {
         initValue3 = (uint8_t)val;
     }
-    if (pReg->initialized && TC6_ReadRegister(pInst, 0x0004008A, &val, TC6_REGS_CONTROL_PROTECTION)) {
+    if (pReg->initialized && RetryRead(pInst, 0x0004008A, &val, TC6_REGS_CONTROL_PROTECTION)) {
         initValue4 = (uint8_t)val;
     }
-    if (pReg->initialized && TC6_ReadRegister(pInst, 0x000400AD, &val, TC6_REGS_CONTROL_PROTECTION)) {
+    if (pReg->initialized && RetryRead(pInst, 0x000400AD, &val, TC6_REGS_CONTROL_PROTECTION)) {
         initValue5 = (uint8_t)val;
     }
-    if (pReg->initialized && TC6_ReadRegister(pInst, 0x000400AE, &val, TC6_REGS_CONTROL_PROTECTION)) {
+    if (pReg->initialized && RetryRead(pInst, 0x000400AE, &val, TC6_REGS_CONTROL_PROTECTION)) {
         initValue6 = (uint8_t)val;
     }
-    if (pReg->initialized && TC6_ReadRegister(pInst, 0x000400AF, &val, TC6_REGS_CONTROL_PROTECTION)) {
+    if (pReg->initialized && RetryRead(pInst, 0x000400AF, &val, TC6_REGS_CONTROL_PROTECTION)) {
         initValue7 = (uint8_t)val;
     }
 

--- a/libtc6/src/tc6.c
+++ b/libtc6/src/tc6.c
@@ -59,6 +59,8 @@ typedef char tc6_check_chunks_xact[(TC6_CHUNKS_XACT >= 1u) ? 1 : -1];
 
 #define TC6_MAGIC           (0x48423578ul)
 #define TC6_CHUNKS_PER_ISR  (2u)
+#define TC6_SPI_RETRY_MAX   (50u)   /* Max retries for SPI transaction busy-wait loops */
+#define TC6_TXC_RETRY_MAX   (200u)  /* Max iterations waiting for TX credits */
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 /*                    INTERNAL DEFINES AND VARIABLES                    */
@@ -162,7 +164,7 @@ static bool accessRegisters(TC6_t *g, MemoryOp_t op, uint32_t addr, uint32_t *va
 static uint8_t get_parity(const uint8_t *pVal);
 static void addEmptyChunks(TC6_t *g, uint16_t chunkCnt);
 static bool spiDataTransaction(TC6_t *g, uint16_t chunkCnt);
-static void waitForTXC(TC6_t *g, uint16_t waitLen);
+static bool waitForTXC(TC6_t *g, uint16_t waitLen);
 
 /* Protocol Implementation */
 static uint16_t mk_ctrl_req(bool wnr, bool aid, uint32_t addr, uint8_t num_regs, const uint32_t *regs, uint8_t *buff, uint16_t size_of_buff);
@@ -201,7 +203,7 @@ TC6_t *TC6_Init(void *pGlobalTag)
 bool TC6_HandleMacPhyInterrupt(uint8_t tc6instance)
 {
     bool success = false;
-    if (tc6instance < TC6_MAX_INSTANCES) {
+    if ((tc6instance < TC6_MAX_INSTANCES) && m_tc6Valid[tc6instance]) {
         TC6_t *g = &m_tc6[tc6instance];
         success = pollRxData(g, true);
     }
@@ -291,7 +293,9 @@ bool TC6_SendRawEthernetSegments(TC6_t *g, const TC6_RawTxSegment *pSegments, ui
         if (chunks > TC6_CHUNKS_XACT) {
             chunks = TC6_CHUNKS_XACT;
         }
-        waitForTXC(g, totalLen);
+        if (!waitForTXC(g, totalLen)) {
+            success = false;
+        }
         for (i = 0u; success && (i < chunks); i++) {
             uint16_t copyPos = 0u;
             uint16_t toCopyLen;
@@ -344,8 +348,17 @@ bool TC6_SendRawEthernetSegments(TC6_t *g, const TC6_RawTxSegment *pSegments, ui
             SET_VAL(HDR_P, get_parity(pSpi), pSpi);
         }
         if (success) {
-            while(!spiDataTransaction(g, chunks));
-            pollRxData(g, false);
+            uint16_t spiRetry = 0u;
+            while (!spiDataTransaction(g, chunks)) {
+                if (++spiRetry >= TC6_SPI_RETRY_MAX) {
+                    TC6_CB_OnError(g, TC6Error_SpiError, g->gTag);
+                    success = false;
+                    break;
+                }
+            }
+            if (success) {
+                pollRxData(g, false);
+            }
         }
     } else {
         success = false;
@@ -614,17 +627,29 @@ static bool spiDataTransaction(TC6_t *g, uint16_t chunkCnt)
     return success;
 }
 
-static void waitForTXC(TC6_t *g, uint16_t waitLen)
+static bool waitForTXC(TC6_t *g, uint16_t waitLen)
 {
     uint16_t waitChunks = (waitLen / TC6_CHUNK_SIZE);
+    uint16_t retries = 0u;
     TC6_ASSERT(g && (TC6_MAGIC == g->magic));
     if (waitLen % TC6_CHUNK_SIZE) {
         waitChunks++;
     }
     while (waitChunks > g->txc) {
+        uint16_t spiRetry = 0u;
         addEmptyChunks(g, 1u);
-        while(!spiDataTransaction(g, 1));
+        while (!spiDataTransaction(g, 1)) {
+            if (++spiRetry >= TC6_SPI_RETRY_MAX) {
+                TC6_CB_OnError(g, TC6Error_SpiError, g->gTag);
+                return false;
+            }
+        }
+        if (++retries >= TC6_TXC_RETRY_MAX) {
+            TC6_CB_OnError(g, TC6Error_SpiError, g->gTag);
+            return false;
+        }
     }
+    return true;
 }
 
 /* Control Transaction API {{{ */
@@ -863,7 +888,11 @@ static inline void process_rx(TC6_t *g, const uint8_t *buff, uint16_t buf_len)
 
             /* ToDo: adjust length according to length of timestamp (32bit or 64bit) */
             if (0u != rtsa) {
-                len -= 8u;
+                if (len > 8u) {
+                    len -= 8u;
+                } else {
+                    len = 0u;
+                }
             }
 
             if (!twoFrames && ev) {
@@ -885,15 +914,25 @@ static bool pollRxData(TC6_t *g, bool forceEmpty)
     bool success = false;
     if ((TC6_MAGIC == g->magic) && (g->enableData)) {
         uint8_t rca = (forceEmpty ? TC6_CHUNKS_PER_ISR : g->rca);
+        success = true;
         while (0u != rca) {
+            uint16_t spiRetry = 0u;
             if (rca > TC6_CHUNKS_XACT) {
                 rca = TC6_CHUNKS_XACT;
             }
             addEmptyChunks(g, rca);
-            while (!spiDataTransaction(g, rca));
+            while (!spiDataTransaction(g, rca)) {
+                if (++spiRetry >= TC6_SPI_RETRY_MAX) {
+                    TC6_CB_OnError(g, TC6Error_SpiError, g->gTag);
+                    success = false;
+                    break;
+                }
+            }
+            if (!success) {
+                break;
+            }
             rca = g->rca;
         }
-        success = true;
     }
     return success;
 }


### PR DESCRIPTION
## Summary

Fixes robustness issues in the synchronous TC6 driver where infinite busy-wait loops could hang on persistent SPI failures, and corrects the extended-status interrupt handler to read both status registers unconditionally.

## Changes

### tc6.c
- Bound all `spiDataTransaction` busy-wait loops with `TC6_SPI_RETRY_MAX` (50) to prevent infinite hangs
- Bound `waitForTXC` outer loop with `TC6_TXC_RETRY_MAX` (200)
- Report `TC6Error_SpiError` and return failure on exhaustion
- Guard `TC6_HandleMacPhyInterrupt` against uninitialised instances
- Protect `process_rx` against underflow when subtracting timestamp length

### tc6-regs.c
- Read both Status0 and Status1 unconditionally in `TC6_CB_OnExtendedStatus` — previously Status1 was only read when Status0 was zero, missing simultaneous flags
- Remove stale `extBlock` struct member; use a local variable instead
- Skip uninitialised slots in `TC6Regs_CheckTimers` (NULL `pTC6` guard)
- Propagate `ReadIndirectReg` failures instead of always returning true
- Use `RetryRead` instead of raw `TC6_ReadRegister` in `InitChip` for consistency
- Add NULL guard for `pReg` in `TC6_CB_OnExtendedStatus`