### PR TITLE
Update initial value for LAN865x Rev.B1 (sync branch)

### DIFF
--- a/libtc6/inc/tc6.h
+++ b/libtc6/inc/tc6.h
@@ -54,8 +54,8 @@ extern "C" {
 
 #define TC6_LIB_VER_MAJOR  (3U)
 #define TC6_LIB_VER_MINOR  (1U)
-#define TC6_LIB_VER_BUGFIX (3U)
-#define TC6_LIB_VER_STRING "V3.1.3-sync"
+#define TC6_LIB_VER_BUGFIX (6U)
+#define TC6_LIB_VER_STRING "V3.1.6-sync"
 
 struct TC6_t;
 typedef struct TC6_t TC6_t;

--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -330,8 +330,15 @@ static void DoInitialization(TC6Reg_t *pReg)
     static const MemoryMap_t TC6_MEMMAP[] = {
         {  .address=0x00000004,  .value=0x00000026,  .mask=0x00000000,  .op=MemOp_Write,  .secure=false }, /* CONFIG0 */
         {  .address=0x00010000,  .value=0x00000000,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  }, /* NETWORK_CONTROL */
+        {  .address=0x000400D0,  .value=0x00003F31,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
+        {  .address=0x000400E0,  .value=0x0000C000,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
+        {  .address=0x000400E9,  .value=0x00009E50,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
+        {  .address=0x000400F5,  .value=0x00001CF8,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
+        {  .address=0x000400F4,  .value=0x0000C020,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
+        {  .address=0x000400F8,  .value=0x0000B900,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
+        {  .address=0x000400F9,  .value=0x00004E53,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
+        {  .address=0x00040081,  .value=0x00000080,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  }, /* DEEP_SLEEP_CTRL_1 */
         {  .address=0x00040091,  .value=0x00009660,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
-        {  .address=0x00040081,  .value=0x00000080,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
         {  .address=0x00010077,  .value=0x00000028,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
         {  .address=0x00040043,  .value=0x000000FF,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
         {  .address=0x00040044,  .value=0x0000FFFF,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
@@ -341,12 +348,7 @@ static void DoInitialization(TC6Reg_t *pReg)
         {  .address=0x00040055,  .value=0x00000000,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
         {  .address=0x00040040,  .value=0x00000002,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
         {  .address=0x00040050,  .value=0x00000002,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
-        {  .address=0x000400E9,  .value=0x00009E50,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
-        {  .address=0x000400F5,  .value=0x00001CF8,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
-        {  .address=0x000400F4,  .value=0x0000C020,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
-        {  .address=0x000400F8,  .value=0x00009B00,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
-        {  .address=0x000400F9,  .value=0x00004E53,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
-        {  .address=0x000400B0,  .value=0x00000103,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
+        {  .address=0x000400B0,  .value=0x00000103,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  }, /*SQI CONFIGURATION*/
         {  .address=0x000400B1,  .value=0x00000910,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
         {  .address=0x000400B2,  .value=0x00001D26,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
         {  .address=0x000400B3,  .value=0x0000002A,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
@@ -360,7 +362,6 @@ static void DoInitialization(TC6Reg_t *pReg)
         {  .address=0x000400BB,  .value=0x0000002B,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  },
 
         {  .address=0x0000000C,  .value=0x00000100,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  }, /* IMASK0 */
-        {  .address=0x00040081,  .value=0x000000E0,  .mask=0x00000000,  .op=MemOp_Write,  .secure=true  }, /* DEEP_SLEEP_CTRL_1 */
     };
 
     static const uint32_t TC6_MEMMAP_LENGTH = (sizeof(TC6_MEMMAP) / sizeof(MemoryMap_t));
@@ -396,11 +397,6 @@ static void DoInitialization(TC6Reg_t *pReg)
         /* Start with default settings */
         while (pReg->initialized && (i < TC6_MEMMAP_LENGTH)) {
             i += TC6_MultipleRegisterAccess(pReg->pTC6, &TC6_MEMMAP[i], (uint16_t)(TC6_MEMMAP_LENGTH - i));
-        }
-        regVal = (1u == pReg->chipRev) ? 0x5F21ul : 0x3F31ul;
-        (void)RetryWrite(pReg->pTC6, 0x000400D0, regVal, TC6_REGS_CONTROL_PROTECTION);
-        if (pReg->initialized && (2u == pReg->chipRev)) {
-            (void)RetryWrite(pReg->pTC6, 0x000400E0, 0x0000C000, TC6_REGS_CONTROL_PROTECTION);
         }
         /* MAC address setting */
         regVal = ((uint32_t)pReg->mac[3] << 24) | ((uint32_t)pReg->mac[2] << 16) | ((uint32_t)pReg->mac[1] << 8) | (uint32_t)pReg->mac[0];

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,10 @@
 
 # OPEN Alliance TC6 Protocol Driver for LAN8650/1 Release Notes
 
+## OPEN Alliance TC6 Protocol Driver for LAN8650/1 Release v3.1.6-sync
+### Bugfixes
+ - Updated initial value for LAN865x Rev.B1.
+
 ## OPEN Alliance TC6 Protocol Driver for LAN8650/1 Release v3.1.3-sync
 ### Bugfixes
 


### PR DESCRIPTION
Port Jing's register initialization changes from master branch v3.1.5.

## Changes
- Add 0x000400D0 and 0x000400E0 to TC6_MEMMAP table (unconditional)
- Move 0x000400E9–0x000400F9 block earlier in table
- Fix 0x000400F8 value: 0x00009B00 → 0x0000B900
- Remove chip-rev conditional code
- Remove duplicate 0x00040081 write
- Bump version to 3.1.6-sync