### PR TITLE
Fix magic comparison in TC6LwIP_Service (sync branch)

### DIFF
--- a/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/tc6-lwip.c
+++ b/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/tc6-lwip.c
@@ -210,7 +210,7 @@ void TC6LwIP_Service(void)
     TC6Regs_CheckTimers();
     for (idx = 0; idx < TC6_MAX_INSTANCES; idx++) {
         TC6LwIP_t *lw = &mlw[idx];
-        if (LWIP_TC6_MAGIC != lw->magic) {
+        if (LWIP_TC6_MAGIC == lw->magic) {
             if (lw->tc.reinit) {
                 lw->tc.reinit = false;
                 TC6Regs_Reinit(lw->tc.tc6);

--- a/examples/lwIP-SAM-E54-xplained-pro/app/firmware/src/tc6-lwip.c
+++ b/examples/lwIP-SAM-E54-xplained-pro/app/firmware/src/tc6-lwip.c
@@ -210,7 +210,7 @@ void TC6LwIP_Service(void)
     TC6Regs_CheckTimers();
     for (idx = 0; idx < TC6_MAX_INSTANCES; idx++) {
         TC6LwIP_t *lw = &mlw[idx];
-        if (LWIP_TC6_MAGIC != lw->magic) {
+        if (LWIP_TC6_MAGIC == lw->magic) {
             if (lw->tc.reinit) {
                 lw->tc.reinit = false;
                 TC6Regs_Reinit(lw->tc.tc6);


### PR DESCRIPTION
Correct the magic field check logic in TC6LwIP_Service from inequality to equality comparison.

Change condition from `LWIP_TC6_MAGIC != lw->magic` to `LWIP_TC6_MAGIC == lw->magic` to correctly check initialized instances.