### PR TITLE
tc6-regs: fix narrowing conversion warnings in PLCA config (sync branch)

### DIFF
--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -528,37 +528,37 @@ static void InitChip(TC6_t *pInst)
 
     /* CONFIG PARAMETER 3 */
     cfgParam = initValue3 & 0x000Fu;
-    tempParam = (int16_t)9 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)(9 + initOffset1); /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 10;
 
-    tempParam = (int16_t)14 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)(14 + initOffset1); /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 4;
 
     (void)RetryWrite(pReg->pTC6, 0x00040084, cfgParam, TC6_REGS_CONTROL_PROTECTION);
 
     /* CONFIG PARAMETER 4 */
     cfgParam = initValue4 & 0x3FFu;
-    tempParam = (int16_t)40 + initOffset2; /* To be MISRA compliant */
+    tempParam = (int16_t)(40 + initOffset2); /* To be MISRA compliant */
     cfgParam |= (uint16_t)(tempParam) << 10;
 
     (void)RetryWrite(pReg->pTC6, 0x0004008A, cfgParam, TC6_REGS_CONTROL_PROTECTION);
 
     /* CONFIG PARAMETER 5 */
     cfgParam = initValue5 & 0xC0C0u;
-    tempParam = (int16_t)5 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)(5 + initOffset1); /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 8;
 
-    tempParam = (int16_t)9 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)(9 + initOffset1); /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam;
 
     (void)RetryWrite(pReg->pTC6, 0x000400AD, cfgParam, TC6_REGS_CONTROL_PROTECTION);
 
     /* CONFIG PARAMETER 6 */
     cfgParam = initValue6 & 0xC0C0u;
-    tempParam = (int16_t)9 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)(9 + initOffset1); /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 8;
 
-    tempParam = (int16_t)14 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)(14 + initOffset1); /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam;
 
     (void)RetryWrite(pReg->pTC6, 0x000400AE, cfgParam, TC6_REGS_CONTROL_PROTECTION);
@@ -566,10 +566,10 @@ static void InitChip(TC6_t *pInst)
     /* CONFIG PARAMETER 7 */
     cfgParam = initValue7 & 0xC0C0u;
 
-    tempParam = (int16_t)17 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)(17 + initOffset1); /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam << 8;
 
-    tempParam = (int16_t)22 + initOffset1; /* To be MISRA compliant */
+    tempParam = (int16_t)(22 + initOffset1); /* To be MISRA compliant */
     cfgParam |= (uint16_t)tempParam;
 
     (void)RetryWrite(pReg->pTC6, 0x000400AF, cfgParam, TC6_REGS_CONTROL_PROTECTION);


### PR DESCRIPTION
## Summary

Fixes 9 clang-tidy `bugprone-narrowing-conversions` warnings in `TC6Regs_Reinit` (CONFIG PARAMETER 3–7 initialization).

## Problem

Type cast applied only to constant literal: `(int16_t)9 + initOffset1`. Integer promotion rules widen the addition result back to `int` before assignment to `int16_t` target, triggering narrowing conversion warnings.

## Solution

Parenthesize the entire addition: `(int16_t)(9 + initOffset1)`. The cast now applies to the result of the addition, keeping the value in `int16_t` type.

## Verification

All register offset values remain within `int16_t` range (register bit-field constraints guarantee this). Changes are mechanical and preserve behavior — no performance impact.

Closes findings from static-analysis scan.