### PR TITLE
Port gPTP/hardware timestamping to the synchronous branch

### DIFF
--- a/examples/lwIP-SAM-E54-Curiosity/app/firmware/demo.X/nbproject/configurations.xml
+++ b/examples/lwIP-SAM-E54-Curiosity/app/firmware/demo.X/nbproject/configurations.xml
@@ -327,6 +327,8 @@
       </logicalFolder>
       <itemPath>../src/app.c</itemPath>
       <itemPath>../src/app.h</itemPath>
+      <itemPath>../src/gptp-gm.c</itemPath>
+      <itemPath>../src/gptp-gm.h</itemPath>
       <itemPath>../src/main.c</itemPath>
       <itemPath>../src/tc6-lwip.h</itemPath>
       <itemPath>../src/tc6-stub.c</itemPath>

--- a/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/gptp-gm.c
+++ b/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/gptp-gm.c
@@ -1,0 +1,271 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include "tc6-conf.h"
+#include "tc6.h"
+#include "tc6-stub.h"
+#include "tc6-lwip.h"
+#include "gptp-gm.h"
+
+/* PTP / 802.1AS frame layout constants */
+#define PTP_ETHERTYPE            (0x88F7u)
+#define PTP_TRANSPORT_SPECIFIC   (0x1u)   /* 802.1AS marker in high nibble of byte 0 */
+#define PTP_MSGTYPE_SYNC         (0x0u)
+#define PTP_MSGTYPE_FOLLOW_UP    (0x8u)
+#define PTP_VERSION              (0x02u)
+#define PTP_FLAG_TWO_STEP        (0x0200u) /* flagField, big-endian: twoStepFlag */
+#define PTP_CONTROL_SYNC         (0x00u)
+#define PTP_CONTROL_FOLLOW_UP    (0x02u)
+#define PTP_HEADER_LEN           (34u)
+#define PTP_TIMESTAMP_LEN        (10u)
+#define PTP_FOLLOWUP_TLV_LEN     (32u)
+#define ETH_HEADER_LEN           (14u)
+#define ETH_MIN_FRAME_LEN        (60u)    /* without FCS */
+#define PTP_SYNC_MSG_LEN         (PTP_HEADER_LEN + PTP_TIMESTAMP_LEN)                        /* 44 */
+#define PTP_FOLLOWUP_MSG_LEN     (PTP_HEADER_LEN + PTP_TIMESTAMP_LEN + PTP_FOLLOWUP_TLV_LEN) /* 76 */
+#define SYNC_FRAME_LEN           (ETH_MIN_FRAME_LEN)                          /* 14+44=58 padded to 60 */
+#define FOLLOWUP_FRAME_LEN       (ETH_HEADER_LEN + PTP_FOLLOWUP_MSG_LEN)      /* 90 */
+#define GPTP_GM_MAX_FRAME_LEN    (96u)    /* >= max(SYNC_FRAME_LEN, FOLLOWUP_FRAME_LEN) */
+
+/* If a sent Sync's TX timestamp callback never arrives, clear the pending
+   state after this long so a single lost capture cannot permanently stall
+   the Grand Master. Uses wrap-safe unsigned tick subtraction. */
+#define GPTP_GM_TS_TIMEOUT_MS    (4u * GPTP_GM_SYNC_INTERVAL_MS)
+
+static const uint8_t GPTP_MCAST_MAC[6] = { 0x01u, 0x80u, 0xC2u, 0x00u, 0x00u, 0x0Eu };
+
+typedef struct
+{
+    int8_t idx;
+    bool initialized;
+    bool enabled;                /* gates Sync transmission; scheduler keeps running */
+    uint8_t srcMac[6];
+    uint8_t clockIdentity[8];
+    uint16_t sequenceId;
+    uint8_t txSlot;              /* 1,2,3 - rotates each Sync */
+    uint32_t nextSyncTick;
+    bool syncPending;            /* a Sync is awaiting its TX timestamp */
+    uint16_t pendingSequenceId;  /* sequenceId of the in-flight Sync */
+    uint8_t pendingSlot;         /* tsc slot of the in-flight Sync */
+    uint32_t pendingSinceTick;   /* tick when the in-flight Sync was enqueued */
+    uint32_t missedCount;        /* timestamp-missed diagnostics */
+    uint8_t syncBuf[GPTP_GM_MAX_FRAME_LEN];
+    uint8_t followUpBuf[GPTP_GM_MAX_FRAME_LEN];
+} GptpGm_t;
+
+static GptpGm_t m_gm[TC6_MAX_INSTANCES];
+
+static void WriteBE16(uint8_t *p, uint16_t v);
+static void WriteBE32(uint8_t *p, uint32_t v);
+static void BuildClockIdentity(const uint8_t mac[6], uint8_t id[8]);
+static uint16_t BuildPtpHeader(uint8_t *buf, const GptpGm_t *gm, uint8_t msgType, uint16_t msgLen, uint16_t seqId, uint8_t control);
+static void BuildSyncFrame(GptpGm_t *gm, uint16_t seqId);
+static void BuildFollowUpFrame(GptpGm_t *gm, uint16_t seqId, uint32_t seconds, uint32_t nanoseconds);
+static void SendSync(GptpGm_t *gm);
+
+static void WriteBE16(uint8_t *p, uint16_t v)
+{
+    p[0] = (uint8_t)(v >> 8);
+    p[1] = (uint8_t)(v & 0xFFu);
+}
+
+static void WriteBE32(uint8_t *p, uint32_t v)
+{
+    p[0] = (uint8_t)(v >> 24);
+    p[1] = (uint8_t)(v >> 16);
+    p[2] = (uint8_t)(v >> 8);
+    p[3] = (uint8_t)(v & 0xFFu);
+}
+
+/* EUI-64 from MAC-48: MAC[0..2] FF FE MAC[3..5] */
+static void BuildClockIdentity(const uint8_t mac[6], uint8_t id[8])
+{
+    id[0] = mac[0];
+    id[1] = mac[1];
+    id[2] = mac[2];
+    id[3] = 0xFFu;
+    id[4] = 0xFEu;
+    id[5] = mac[3];
+    id[6] = mac[4];
+    id[7] = mac[5];
+}
+
+/* Fills the 14-byte Ethernet header + 34-byte PTP common header.
+   Returns the offset just past the common header (== ETH_HEADER_LEN + PTP_HEADER_LEN). */
+static uint16_t BuildPtpHeader(uint8_t *buf, const GptpGm_t *gm, uint8_t msgType, uint16_t msgLen, uint16_t seqId, uint8_t control)
+{
+    uint8_t *e = buf;
+    uint8_t *h = &buf[ETH_HEADER_LEN];
+
+    /* Ethernet header */
+    (void)memcpy(&e[0], GPTP_MCAST_MAC, 6);
+    (void)memcpy(&e[6], gm->srcMac, 6);
+    WriteBE16(&e[12], PTP_ETHERTYPE);
+
+    /* PTP common header (34 bytes) */
+    (void)memset(h, 0, PTP_HEADER_LEN);
+    h[0]  = (uint8_t)((PTP_TRANSPORT_SPECIFIC << 4) | (msgType & 0x0Fu));
+    h[1]  = PTP_VERSION;
+    WriteBE16(&h[2], msgLen);
+    h[4]  = GPTP_GM_DOMAIN_NUMBER;
+    /* h[5] reserved = 0 */
+    WriteBE16(&h[6], (PTP_MSGTYPE_SYNC == msgType) ? PTP_FLAG_TWO_STEP : 0x0000u);
+    /* h[8..15] correctionField = 0; h[16..19] reserved = 0 */
+    (void)memcpy(&h[20], gm->clockIdentity, 8); /* sourcePortIdentity.clockIdentity */
+    WriteBE16(&h[28], 1u);                       /* sourcePortIdentity.portNumber = 1 */
+    WriteBE16(&h[30], seqId);
+    h[32] = control;
+    h[33] = (uint8_t)GPTP_GM_LOG_SYNC_INTERVAL;  /* logMessageInterval */
+
+    return (uint16_t)(ETH_HEADER_LEN + PTP_HEADER_LEN);
+}
+
+static void BuildSyncFrame(GptpGm_t *gm, uint16_t seqId)
+{
+    uint16_t off;
+    (void)memset(gm->syncBuf, 0, sizeof(gm->syncBuf));
+    off = BuildPtpHeader(gm->syncBuf, gm, PTP_MSGTYPE_SYNC, PTP_SYNC_MSG_LEN, seqId, PTP_CONTROL_SYNC);
+    /* originTimestamp (10 bytes) left zero for two-step. Frame zero-padded to 60 bytes. */
+    (void)off;
+}
+
+static void BuildFollowUpFrame(GptpGm_t *gm, uint16_t seqId, uint32_t seconds, uint32_t nanoseconds)
+{
+    uint16_t off;
+    uint8_t *b;
+    (void)memset(gm->followUpBuf, 0, sizeof(gm->followUpBuf));
+    off = BuildPtpHeader(gm->followUpBuf, gm, PTP_MSGTYPE_FOLLOW_UP, PTP_FOLLOWUP_MSG_LEN, seqId, PTP_CONTROL_FOLLOW_UP);
+    b = &gm->followUpBuf[off];
+
+    /* preciseOriginTimestamp: 6-byte seconds (top 2 bytes zero) + 4-byte nanoseconds */
+    b[0] = 0u;
+    b[1] = 0u;
+    WriteBE32(&b[2], seconds);
+    WriteBE32(&b[6], nanoseconds);
+    b += PTP_TIMESTAMP_LEN;
+
+    /* Follow_Up information TLV (organizationExtension), 32 bytes total */
+    WriteBE16(&b[0], 0x0003u); /* tlvType = ORGANIZATION_EXTENSION */
+    WriteBE16(&b[2], 28u);     /* lengthField */
+    b[4] = 0x00u; b[5] = 0x80u; b[6] = 0xC2u;       /* OUI 00-80-C2 (IEEE 802.1) */
+    b[7] = 0x00u; b[8] = 0x00u; b[9] = 0x01u;       /* organizationSubType = 1 */
+    /* cumulativeScaledRateOffset(4), gmTimeBaseIndicator(2),
+       lastGmPhaseChange(12), scaledLastGmFreqChange(4) all zero (bytes 10..31). */
+}
+
+static void SendSync(GptpGm_t *gm)
+{
+    uint16_t seq = gm->sequenceId;
+    uint8_t slot = gm->txSlot;
+
+    BuildSyncFrame(gm, seq);
+    if (TC6LwIP_SendRawEthernetPacket(gm->idx, gm->syncBuf, SYNC_FRAME_LEN, slot)) {
+        gm->syncPending = true;
+        gm->pendingSequenceId = seq;
+        gm->pendingSlot = slot;
+        gm->pendingSinceTick = TC6Stub_GetTick();
+        gm->sequenceId++;
+        gm->txSlot = (slot >= 3u) ? 1u : (uint8_t)(slot + 1u);
+    }
+    /* If enqueue failed, leave state unchanged; the next Service tick retries. */
+}
+
+bool gPTP_GM_Init(int8_t idx)
+{
+    bool success = false;
+    if ((idx >= 0) && (idx < TC6_MAX_INSTANCES)) {
+        GptpGm_t *gm = &m_gm[idx];
+        uint8_t *macPtr = NULL;
+        (void)memset(gm, 0, sizeof(*gm));
+        gm->idx = idx;
+        if (TC6LwIP_GetTimestampSupported(idx)) {
+            TC6LwIP_GetMacAddress(idx, &macPtr); /* macPtr -> internal 6-byte MAC */
+            if (NULL != macPtr) {
+                (void)memcpy(gm->srcMac, macPtr, 6);
+                BuildClockIdentity(gm->srcMac, gm->clockIdentity);
+                gm->sequenceId = 0u;
+                gm->txSlot = 1u;
+                gm->syncPending = false;
+                gm->nextSyncTick = TC6Stub_GetTick() + GPTP_GM_SYNC_INTERVAL_MS;
+                gm->enabled = true;
+                gm->initialized = true;
+                success = true;
+            }
+        }
+    }
+    return success;
+}
+
+void gPTP_GM_Service(void)
+{
+    uint8_t i;
+    uint32_t now = TC6Stub_GetTick();
+    for (i = 0u; i < TC6_MAX_INSTANCES; i++) {
+        GptpGm_t *gm = &m_gm[i];
+        if (gm->initialized) {
+            /* Watchdog: if the TX timestamp for an in-flight Sync never came
+               back, release the pending state so sending can resume. */
+            if (gm->syncPending && ((uint32_t)(now - gm->pendingSinceTick) >= GPTP_GM_TS_TIMEOUT_MS)) {
+                gm->syncPending = false;
+                gm->missedCount++;
+            }
+            if ((int32_t)(now - gm->nextSyncTick) >= 0) {
+                /* Absolute rescheduling: advance the deadline from itself, not
+                   from now, so per-cycle observation latency is absorbed and
+                   the mean interval stays at GPTP_GM_SYNC_INTERVAL_MS instead
+                   of drifting long. The (int32_t) subtraction is wrap-safe
+                   across the 32-bit ms tick rollover. If we ever fall a full
+                   interval behind (e.g. a long stall), re-snap to now so we
+                   emit one Sync rather than bursting to catch up. */
+                gm->nextSyncTick += GPTP_GM_SYNC_INTERVAL_MS;
+                if ((int32_t)(now - gm->nextSyncTick) >= 0) {
+                    gm->nextSyncTick = now + GPTP_GM_SYNC_INTERVAL_MS;
+                }
+                if (gm->enabled && !gm->syncPending) {
+                    SendSync(gm);
+                }
+                /* If a Sync is still pending (timestamp not yet returned), skip
+                   this cycle rather than overlap; the watchdog above and the
+                   missed-timestamp path both clear a stuck pending state. */
+            }
+        }
+    }
+}
+
+void gPTP_GM_OnTxTimestamp(int8_t idx, bool success, uint8_t tsc, uint64_t timestamp)
+{
+    if ((idx >= 0) && (idx < TC6_MAX_INSTANCES)) {
+        GptpGm_t *gm = &m_gm[idx];
+        if (gm->initialized && gm->syncPending && (tsc == gm->pendingSlot)) {
+            gm->syncPending = false;
+            if (success) {
+                uint32_t seconds = (uint32_t)(timestamp >> 32);
+                uint32_t nanos = (uint32_t)(timestamp & 0xFFFFFFFFu);
+                BuildFollowUpFrame(gm, gm->pendingSequenceId, seconds, nanos);
+                (void)TC6LwIP_SendRawEthernetPacket(idx, gm->followUpBuf, FOLLOWUP_FRAME_LEN, 0u);
+            } else {
+                gm->missedCount++; /* skip this Follow_Up, no retry */
+            }
+        }
+    }
+}
+
+void gPTP_GM_SetEnabled(int8_t idx, bool enable)
+{
+    if ((idx >= 0) && (idx < TC6_MAX_INSTANCES)) {
+        GptpGm_t *gm = &m_gm[idx];
+        if (gm->initialized) {
+            gm->enabled = enable;
+        }
+    }
+}
+
+bool gPTP_GM_IsEnabled(int8_t idx)
+{
+    bool enabled = false;
+    if ((idx >= 0) && (idx < TC6_MAX_INSTANCES)) {
+        GptpGm_t *gm = &m_gm[idx];
+        enabled = (gm->initialized && gm->enabled);
+    }
+    return enabled;
+}

--- a/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/gptp-gm.h
+++ b/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/gptp-gm.h
@@ -1,0 +1,43 @@
+#ifndef GPTP_GM_H_
+#define GPTP_GM_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/*>>>>>>>>>>>>>>>>>>>>>>>> USER ADJUSTABLE >>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
+#define GPTP_GM_DOMAIN_NUMBER        (0u)   /* gPTP domain 0 */
+#define GPTP_GM_LOG_SYNC_INTERVAL    (-3)   /* 2^-3 s = 125 ms (Automotive default) */
+#define GPTP_GM_SYNC_INTERVAL_MS     (125u) /* must equal 1000 * 2^GPTP_GM_LOG_SYNC_INTERVAL */
+/*<<<<<<<<<<<<<<<<<<<<<<<< USER ADJUSTABLE <<<<<<<<<<<<<<<<<<<<<<<<<<<*/
+
+/** \brief Initializes the gPTP Automotive-profile Grand Master for an instance.
+ *  \note Call after TC6LwIP_Init() succeeds. Fails if timestamping is unsupported.
+ *  \param idx - instance index returned by TC6LwIP_Init()
+ *  \return true on success */
+bool gPTP_GM_Init(int8_t idx);
+
+/** \brief Drives the GM scheduler. Call from the main loop next to TC6LwIP_Service(). */
+void gPTP_GM_Service(void);
+
+/** \brief Delivers a captured TX timestamp for a previously sent Sync frame.
+ *  \note Called by tc6-lwip.c's OnTxTimestamp handler. Triggers Follow_Up send.
+ *  \param idx - instance index
+ *  \param success - true if the timestamp read succeeded
+ *  \param tsc - capture slot (1/2/3) that was used for the Sync
+ *  \param timestamp - 64-bit capture: seconds in high 32 bits, nanoseconds in low 32 */
+void gPTP_GM_OnTxTimestamp(int8_t idx, bool success, uint8_t tsc, uint64_t timestamp);
+
+/** \brief Enables or disables Sync transmission for an instance.
+ *  \note When disabled the periodic scheduler keeps running (timer advances,
+ *        watchdog still runs) but no new Sync is sent. A Sync already in flight
+ *        still gets its Follow_Up. Does not affect the LAN865x 1PPS output.
+ *  \param idx - instance index
+ *  \param enable - true to send Sync frames, false to suppress them */
+void gPTP_GM_SetEnabled(int8_t idx, bool enable);
+
+/** \brief Reports whether Sync transmission is currently enabled.
+ *  \param idx - instance index
+ *  \return true if the instance is initialized and enabled */
+bool gPTP_GM_IsEnabled(int8_t idx);
+
+#endif /* GPTP_GM_H_ */

--- a/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/main.c
+++ b/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/main.c
@@ -53,6 +53,7 @@ Microchip or any third party.
 
 #include "tc6.h"
 #include "tc6-lwip.h"
+#include "gptp-gm.h"
 #include "udp_perf_client.h"
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
@@ -72,6 +73,7 @@ Microchip or any third party.
 #define MAC_PROMISCUOUS_MODE        (false)
 #define MAC_TX_CUT_THROUGH          (false)
 #define MAC_RX_CUT_THROUGH          (false)
+#define MAC_ENABLE_TIMESTAMP        (true)
 #define DELAY_BEACON_CHECK          (1000)
 #define DELAY_LED                   (333)
 
@@ -145,10 +147,15 @@ int main(void)
 
     m.idxLwIp = TC6LwIP_Init(m_ip, T1S_PLCA_ENABLE, T1S_PLCA_NODE_ID, T1S_PLCA_NODE_COUNT,
         T1S_PLCA_BURST_COUNT, T1S_PLCA_BURST_TIMER, MAC_PROMISCUOUS_MODE,
-        MAC_TX_CUT_THROUGH, MAC_RX_CUT_THROUGH);
+        MAC_TX_CUT_THROUGH, MAC_RX_CUT_THROUGH, MAC_ENABLE_TIMESTAMP);
 
     if (m.idxLwIp < 0) {
         PRINT(ESC_RED "Failed to initialize TC6 lwIP Driver" ESC_RESETCOLOR "\r\n");
+        goto ERROR;
+    }
+
+    if (!gPTP_GM_Init(m.idxLwIp)) {
+        PRINT(ESC_RED "Failed to initialize gPTP Grand Master (timestamping unsupported?)" ESC_RESETCOLOR "\r\n");
         goto ERROR;
     }
 
@@ -165,6 +172,7 @@ int main(void)
         SYS_Tasks();
         iperf_service();
         TC6LwIP_Service();
+        gPTP_GM_Service();
 
         now = systick.tickCounter;
         if (DELAY_BEACON_CHECK && now > m.nextBeaconCheck) {
@@ -212,6 +220,7 @@ static void PrintMenu()
     PRINT(" r - soft reset\r\n");
     PRINT(" c - clear screen\r\n");
     PRINT(" i - toggle iperf tx test\r\n");
+    PRINT(" p - toggle gPTP Grand Master sync tx\r\n");
     PRINT("======================\r\n");
 }
 
@@ -244,6 +253,11 @@ static void CheckUartInput(void)
                     PRINT("iperf client stop\r\n");
                     iperf_stop_application();
                 }
+                break;
+            case 'P':
+            case 'p':
+                gPTP_GM_SetEnabled(m.idxLwIp, !gPTP_GM_IsEnabled(m.idxLwIp));
+                PRINT("gPTP Grand Master sync tx %s\r\n", gPTP_GM_IsEnabled(m.idxLwIp) ? "ON" : "OFF");
                 break;
             default:
                 PRINT("Unknown key='%c'(0x%X)\r\n", m_rx, m_rx);

--- a/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/tc6-lwip.c
+++ b/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/tc6-lwip.c
@@ -54,6 +54,7 @@ Microchip or any third party.
 #include "tc6.h"
 #include "tc6-stub.h"
 #include "tc6-lwip.h"
+#include "gptp-gm.h"
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 /*                          USER ADJUSTABLE                             */
@@ -711,7 +712,7 @@ uint32_t TC6Regs_CB_GetTicksMs(void)
 
 static void OnTxTimestamp(TC6_t *pInst, bool success, uint8_t tsc, uint64_t timestamp, void *pTag)
 {
-    (void)pInst;
+    TC6LwIP_t *lw = GetContextTC6(pInst);
     (void)pTag;
     if (success) {
         /* Brief per-Sync line: slot letter (A/B/C) + nanoseconds-within-second.
@@ -725,6 +726,9 @@ static void OnTxTimestamp(TC6_t *pInst, bool success, uint8_t tsc, uint64_t time
         }
     } else {
         PRINT(ESC_RED "Sync(tsc=%d) ts read failed" ESC_RESETCOLOR "\r\n", tsc);
+    }
+    if (NULL != lw) {
+        gPTP_GM_OnTxTimestamp(lw->idx, success, tsc, timestamp);
     }
 }
 

--- a/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/tc6-lwip.c
+++ b/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/tc6-lwip.c
@@ -85,6 +85,7 @@ typedef struct
 {
     TC6_t *tc6;
     struct pbuf *pbuf;
+    TC6LwIP_OnRxTimestamp pRxTimestampCallback;
     uint16_t rxLen;
     bool rxInvalid;
     bool reinit;
@@ -115,6 +116,7 @@ static bool FilterRxEthernetPacket(uint16_t ethType);
 static void PrintRateLimited(const char *statement, ...);
 static TC6LwIP_t *GetContextNetif(struct netif *intf);
 static TC6LwIP_t *GetContextTC6(TC6_t *pTC6);
+static void OnTxTimestamp(TC6_t *pInst, bool success, uint8_t tsc, uint64_t timestamp, void *pTag);
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 /*                  CALLBACK FUNCTIONS FROM TCP/IP STACK                */
@@ -127,7 +129,7 @@ static err_t lwIpOut(struct netif *netif, struct pbuf *p);
 /*                         PUBLIC FUNCTIONS                             */
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 
-int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough)
+int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough, bool enableTimestamp)
 {
     TC6LwIP_t *lw = NULL;
     uint8_t i;
@@ -162,7 +164,7 @@ int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_
         success = (NULL != lw->tc.tc6);
     }
     if (success) {
-        success = TC6Regs_Init(lw->tc.tc6, lw, lw->ip.mac, enablePlca, nodeId, nodeCount, burstCount, burstTimer, promiscuous, txCutThrough, rxCutThrough);
+        success = TC6Regs_Init(lw->tc.tc6, lw, lw->ip.mac, enablePlca, nodeId, nodeCount, burstCount, burstTimer, promiscuous, txCutThrough, rxCutThrough, enableTimestamp);
     }
     if (success) {
         while(!TC6Regs_GetInitDone(lw->tc.tc6)) {
@@ -249,6 +251,44 @@ bool TC6LwIP_SetPlca(int8_t idx, bool plcaEnable, uint8_t nodeId, uint8_t nodeCo
         success = TC6Regs_SetPlca(lw->tc.tc6, plcaEnable, nodeId, nodeCount);
     }
     return success;
+}
+
+bool TC6LwIP_SendRawEthernetPacket(int8_t idx, const uint8_t *pTx, uint16_t len, uint8_t tsc)
+{
+    bool success = false;
+    if ((idx < TC6_MAX_INSTANCES) && (NULL != pTx) && (0u != len)) {
+        TC6LwIP_t *lw = &mlw[idx];
+        success = TC6_SendRawEthernetPacket(lw->tc.tc6, pTx, len, tsc);
+    }
+    return success;
+}
+
+bool TC6LwIP_GetTimestampSupported(int8_t idx)
+{
+    bool supported = false;
+    if (idx < TC6_MAX_INSTANCES) {
+        TC6LwIP_t *lw = &mlw[idx];
+        supported = TC6Regs_GetTimestampSupported(lw->tc.tc6);
+    }
+    return supported;
+}
+
+bool TC6LwIP_ReadTxTimestamp(int8_t idx, uint8_t tsc, uint64_t *pTimestamp)
+{
+    bool success = false;
+    if ((idx < TC6_MAX_INSTANCES) && (NULL != pTimestamp)) {
+        TC6LwIP_t *lw = &mlw[idx];
+        success = TC6Regs_ReadTxTimestamp(lw->tc.tc6, tsc, pTimestamp);
+    }
+    return success;
+}
+
+void TC6LwIP_SetRxTimestampCallback(int8_t idx, TC6LwIP_OnRxTimestamp callback)
+{
+    if (idx < TC6_MAX_INSTANCES) {
+        TC6LwIP_t *lw = &mlw[idx];
+        lw->tc.pRxTimestampCallback = callback;
+    }
 }
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
@@ -438,12 +478,14 @@ void TC6_CB_OnRxEthernetPacket(TC6_t *pInst, bool success, uint16_t len, uint64_
     uint16_t ethType;
     struct eth_hdr *ethhdr;
     (void)pInst;
-    (void)rxTimestamp;
     (void)pGlobalTag;
     TC6_ASSERT(lw->tc.tc6 == pInst);
     bool result = true;
     if (!success || lw->tc.rxInvalid || !lw->tc.pbuf || !lw->tc.rxLen) {
         result = false;
+    }
+    if (result && success && (NULL != rxTimestamp) && (NULL != lw->tc.pRxTimestampCallback)) {
+        lw->tc.pRxTimestampCallback(lw->idx, *rxTimestamp);
     }
     if (result && (lw->tc.rxLen != len)) {
         PrintRateLimited("on_rx_eth_ready: size mismatch", 0u);
@@ -568,13 +610,27 @@ uint32_t TC6Regs_CB_GetTicksMs(void)
         PRINT(ESC_GREEN "PHY_Interrupt" ESC_RESETCOLOR "\r\n");
         break;
     case TC6Regs_Event_Transmit_Timestamp_Capture_Available_A:
-        PRINT(ESC_GREEN "Transmit_Timestamp_Capture_Available_A" ESC_RESETCOLOR "\r\n");
+        {
+            /* Capture-available events fire per Sync; the brief Sync(x)= line in
+               OnTxTimestamp is the only per-Sync output to keep the UART quiet. */
+            uint64_t ts = 0u;
+            bool tsOk = TC6Regs_ReadTxTimestamp(pInst, 1u, &ts);
+            OnTxTimestamp(pInst, tsOk, 1u, ts, pTag);
+        }
         break;
     case TC6Regs_Event_Transmit_Timestamp_Capture_Available_B:
-        PRINT(ESC_GREEN "Transmit_Timestamp_Capture_Available_B" ESC_RESETCOLOR "\r\n");
+        {
+            uint64_t ts = 0u;
+            bool tsOk = TC6Regs_ReadTxTimestamp(pInst, 2u, &ts);
+            OnTxTimestamp(pInst, tsOk, 2u, ts, pTag);
+        }
         break;
     case TC6Regs_Event_Transmit_Timestamp_Capture_Available_C:
-        PRINT(ESC_GREEN "Transmit_Timestamp_Capture_Available_C" ESC_RESETCOLOR "\r\n");
+        {
+            uint64_t ts = 0u;
+            bool tsOk = TC6Regs_ReadTxTimestamp(pInst, 3u, &ts);
+            OnTxTimestamp(pInst, tsOk, 3u, ts, pTag);
+        }
         break;
     case TC6Regs_Event_Transmit_Frame_Check_Sequence_Error:
         PRINT(ESC_RED "Transmit_Frame_Check_Sequence_Error" ESC_RESETCOLOR "\r\n");
@@ -652,6 +708,25 @@ uint32_t TC6Regs_CB_GetTicksMs(void)
         break;
     }
  }
+
+static void OnTxTimestamp(TC6_t *pInst, bool success, uint8_t tsc, uint64_t timestamp, void *pTag)
+{
+    (void)pInst;
+    (void)pTag;
+    if (success) {
+        /* Brief per-Sync line: slot letter (A/B/C) + nanoseconds-within-second.
+           At the 125 ms Automotive rate 8 Syncs/sec overruns the UART rate
+           limiter, so print only every 8th (~1/sec) to avoid "[skipped N]"
+           while still showing liveness and the slot rotating. */
+        static uint32_t tsPrintDiv = 0u;
+        if (0u == (tsPrintDiv++ & 0x7u)) {
+            char slot = (char)('A' + (((tsc >= 1u) && (tsc <= 3u)) ? (tsc - 1u) : 0u));
+            PRINT("Sync(%c)=%09lu\r\n", slot, (unsigned long)(timestamp & 0xFFFFFFFFu));
+        }
+    } else {
+        PRINT(ESC_RED "Sync(tsc=%d) ts read failed" ESC_RESETCOLOR "\r\n", tsc);
+    }
+}
 
 bool TC6_CB_OnSpiTransaction(uint8_t tc6instance, const uint8_t *pTx, uint8_t *pRx, uint16_t len, void *pGlobalTag)
 {

--- a/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/tc6-lwip.h
+++ b/examples/lwIP-SAM-E54-Curiosity/app/firmware/src/tc6-lwip.h
@@ -44,6 +44,7 @@ Microchip or any third party.
 #include <stdint.h>
 #include <stdbool.h>
 #include "tc6.h"
+#include "tc6-regs.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -74,9 +75,10 @@ extern "C" {
  *  \promiscuous - true, when RX MAC filter shall be turned off, then all messages are getting received (sniffing). false, filter is active, only messages with matching MACs (and broadcast/multicast) are getting received.
  *  \txCutThrough - true, when TX cut through shall be active, this helps improving speed further. Note that in that case the MCU/MPU must be able to send at full network speed. false, activates TX store and forward mode.
  *  \rxCutThrough - true, when RX cut through shall be active, this helps improving speed further. Note that in that case the MCU/MPU must be able to receive at full network speed. false, activates RX store and forward mode.
+ *  \enableTimestamp - true, if hardware TX/RX timestamping shall be enabled (when the PHY supports it). false, timestamping stays off.
  *  \return The instance number of the current TC6LwIP driver. Starting at 0 and incrementing by one for any further call. Returns -1 when a instance can not be initialized, increase TC6_MAX_INSTANCES.
  */
-int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough);
+int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough, bool enableTimestamp);
 
 /** \brief Services the hardware and the protocol stack.
  *  \note Must be called cyclic. The faster the better.
@@ -104,6 +106,42 @@ void TC6LwIP_GetMacAddress(int8_t idx, uint8_t *mac[6]);
  *  \return true, if request could be enqueued, the PLCA parameters will be changed soon. false, request failed, no change.
  */
 bool TC6LwIP_SetPlca(int8_t idx, bool plcaEnable, uint8_t nodeId, uint8_t nodeCount);
+
+/** \brief Sends a raw Ethernet frame, optionally requesting a TX timestamp capture.
+ *  \param idx - The instance number as returned from the TC6LwIP_Init() function.
+ *  \param pTx - Pointer to the full Ethernet frame (dst/src/ethertype + payload).
+ *  \param len - Frame length in bytes.
+ *  \param tsc - Timestamp capture slot 1/2/3, or 0 for no timestamp.
+ *  \return true, if the frame was sent.
+ */
+bool TC6LwIP_SendRawEthernetPacket(int8_t idx, const uint8_t *pTx, uint16_t len, uint8_t tsc);
+
+/** \brief Reports whether the MAC-PHY supports hardware TX/RX frame timestamping.
+ *  \param idx - The instance number as returned from the TC6LwIP_Init() function.
+ *  \return true, if timestamping hardware is available and enabled.
+ */
+bool TC6LwIP_GetTimestampSupported(int8_t idx);
+
+/** \brief Reads back a hardware TX timestamp capture slot.
+ *  \param idx - The instance number as returned from the TC6LwIP_Init() function.
+ *  \param tsc - The capture slot (1=A, 2=B, 3=C) as used with TC6LwIP_SendRawEthernetPacket()'s tsc argument.
+ *  \param pTimestamp - Out: the 64-bit timestamp, valid only if this function returns true.
+ *  \return true, if the timestamp was read successfully.
+ */
+bool TC6LwIP_ReadTxTimestamp(int8_t idx, uint8_t tsc, uint64_t *pTimestamp);
+
+/**
+ * \brief Callback invoked with a hardware RX timestamp.
+ * \param idx - The instance number as returned from the TC6LwIP_Init() function.
+ * \param timestamp - The 64-bit hardware RX timestamp of the most recently received packet.
+ */
+typedef void (*TC6LwIP_OnRxTimestamp)(int8_t idx, uint64_t timestamp);
+
+/** \brief Registers a callback that is invoked with the hardware RX timestamp of every received packet.
+ *  \param idx - The instance number as returned from the TC6LwIP_Init() function.
+ *  \param callback - The callback to invoke, or NULL to unregister.
+ */
+void TC6LwIP_SetRxTimestampCallback(int8_t idx, TC6LwIP_OnRxTimestamp callback);
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 /*                 Callback implementations from TC6 library            */

--- a/examples/lwIP-SAM-E54-xplained-pro/app/firmware/src/main.c
+++ b/examples/lwIP-SAM-E54-xplained-pro/app/firmware/src/main.c
@@ -144,7 +144,7 @@ int main(void)
 
     m.idxLwIp = TC6LwIP_Init(m_ip, T1S_PLCA_ENABLE, T1S_PLCA_NODE_ID, T1S_PLCA_NODE_COUNT,
         T1S_PLCA_BURST_COUNT, T1S_PLCA_BURST_TIMER, MAC_PROMISCUOUS_MODE,
-        MAC_TX_CUT_THROUGH, MAC_RX_CUT_THROUGH);
+        MAC_TX_CUT_THROUGH, MAC_RX_CUT_THROUGH, false);
 
     if (m.idxLwIp < 0) {
         PRINT(ESC_RED "Failed to initialize TC6 lwIP Driver" ESC_RESETCOLOR "\r\n");

--- a/examples/lwIP-SAM-E54-xplained-pro/app/firmware/src/tc6-lwip.c
+++ b/examples/lwIP-SAM-E54-xplained-pro/app/firmware/src/tc6-lwip.c
@@ -127,7 +127,7 @@ static err_t lwIpOut(struct netif *netif, struct pbuf *p);
 /*                         PUBLIC FUNCTIONS                             */
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 
-int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough)
+int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough, bool enableTimestamp)
 {
     TC6LwIP_t *lw = NULL;
     uint8_t i;
@@ -162,7 +162,7 @@ int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_
         success = (NULL != lw->tc.tc6);
     }
     if (success) {
-        success = TC6Regs_Init(lw->tc.tc6, lw, lw->ip.mac, enablePlca, nodeId, nodeCount, burstCount, burstTimer, promiscuous, txCutThrough, rxCutThrough);
+        success = TC6Regs_Init(lw->tc.tc6, lw, lw->ip.mac, enablePlca, nodeId, nodeCount, burstCount, burstTimer, promiscuous, txCutThrough, rxCutThrough, enableTimestamp);
     }
     if (success) {
         while(!TC6Regs_GetInitDone(lw->tc.tc6)) {

--- a/examples/lwIP-SAM-E54-xplained-pro/app/firmware/src/tc6-lwip.h
+++ b/examples/lwIP-SAM-E54-xplained-pro/app/firmware/src/tc6-lwip.h
@@ -76,7 +76,7 @@ extern "C" {
  *  \rxCutThrough - true, when RX cut through shall be active, this helps improving speed further. Note that in that case the MCU/MPU must be able to receive at full network speed. false, activates RX store and forward mode.
  *  \return The instance number of the current TC6LwIP driver. Starting at 0 and incrementing by one for any further call. Returns -1 when a instance can not be initialized, increase TC6_MAX_INSTANCES.
  */
-int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough);
+int8_t TC6LwIP_Init(const uint8_t ip[4], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough, bool enableTimestamp);
 
 /** \brief Services the hardware and the protocol stack.
  *  \note Must be called cyclic. The faster the better.

--- a/examples/noIP-SAM-E54-Curiosity/app/firmware/src/main.c
+++ b/examples/noIP-SAM-E54-Curiosity/app/firmware/src/main.c
@@ -353,7 +353,7 @@ int main(void)
 
     m.idxNoIp = TC6NoIP_Init(T1S_PLCA_ENABLE, T1S_PLCA_NODE_ID, T1S_PLCA_NODE_COUNT,
         T1S_PLCA_BURST_COUNT, T1S_PLCA_BURST_TIMER, MAC_PROMISCUOUS_MODE,
-        MAC_TX_CUT_THROUGH, MAC_RX_CUT_THROUGH);
+        MAC_TX_CUT_THROUGH, MAC_RX_CUT_THROUGH, false);
 
     if (m.idxNoIp < 0) {
         PRINT(ESC_RED "%sFailed to initialize TC6 noIP Driver" ESC_RESETCOLOR "\r\n", MoveCursor(true));

--- a/examples/noIP-SAM-E54-Curiosity/app/firmware/src/tc6-noip.c
+++ b/examples/noIP-SAM-E54-Curiosity/app/firmware/src/tc6-noip.c
@@ -100,7 +100,7 @@ static void PrintRateLimited(const char *statement, ...);
 /*                         PUBLIC FUNCTIONS                             */
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 
-int8_t TC6NoIP_Init(bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough)
+int8_t TC6NoIP_Init(bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough, bool enableTimestamp)
 {
     TC6NoIP_t *lw = NULL;
     uint8_t i;
@@ -128,7 +128,7 @@ int8_t TC6NoIP_Init(bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t 
         }
     }
     if (success) {
-        success = TC6Regs_Init(lw->tc.tc6, lw, lw->tc.mac, enablePlca, nodeId, nodeCount, burstCount, burstTimer, promiscuous, txCutThrough, rxCutThrough);
+        success = TC6Regs_Init(lw->tc.tc6, lw, lw->tc.mac, enablePlca, nodeId, nodeCount, burstCount, burstTimer, promiscuous, txCutThrough, rxCutThrough, enableTimestamp);
         if (!success) {
             PRINT_FORCE(ESC_RED "[%d]TC6Regs_Init() failed" ESC_RESETCOLOR "\r\n", lw->idx);
         }

--- a/examples/noIP-SAM-E54-Curiosity/app/firmware/src/tc6-noip.h
+++ b/examples/noIP-SAM-E54-Curiosity/app/firmware/src/tc6-noip.h
@@ -65,7 +65,7 @@ extern "C" {
  *  \rxCutThrough - true, when RX cut through shall be active, this helps improving speed further. Note that in that case the MCU/MPU must be able to receive at full network speed. false, activates RX store and forward mode.
  *  \return The instance number of the current TC6NoIP driver. Starting at 0 and incrementing by one for any further call. Returns -1 when a instance can not be initialized, increase TC6_MAX_INSTANCES.
  */
-int8_t TC6NoIP_Init(bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough);
+int8_t TC6NoIP_Init(bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough, bool enableTimestamp);
 
 /** \brief Services the hardware and the protocol stack.
  *  \note Must be called cyclic. The faster the better.

--- a/libtc6/inc/tc6-regs.h
+++ b/libtc6/inc/tc6-regs.h
@@ -42,6 +42,14 @@ Microchip or any third party.
 /*                            DEFINITIONS                               */
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 
+/** \brief PHC seed value (whole seconds) written to the LAN865x internal 1588
+ *         timer once during TC6Regs_Init(). Integrators may override this.
+ *         Default = 2026-08-07 00:00:00 UTC (seconds since 1970-01-01).
+ *         Value fits in 32 bits, so MAC_TSH (seconds high) seeds to 0. */
+#ifndef TC6Regs_PTP_EPOCH_SEC
+#define TC6Regs_PTP_EPOCH_SEC   (1786060800u)
+#endif
+
 typedef enum
 {
     TC6Regs_Event_UnknownError = 0,

--- a/libtc6/inc/tc6-regs.h
+++ b/libtc6/inc/tc6-regs.h
@@ -92,9 +92,10 @@ typedef enum
  *  \param pInst - The pointer returned by TC6_Init.
  *  \param pTag - This pointer will be returned back with any callback of this component. Maybe set to NULL.
  *  \param mac - The 6 Byte public visible MAC address of the TC6 MAC.
+ *  \param enableTimestamp - true, if hardware TX/RX frame timestamping shall be enabled (requires a timestamp-capable MAC-PHY, see TC6Regs_GetTimestampSupported()).
  *  \return True, if initial register settings and given parameters have been written into the LAN865x. false, initialization error, try again later with TC6Regs_Reinit().
  */
-bool TC6Regs_Init(TC6_t *pInst, void *pTag, const uint8_t mac[6], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough);
+bool TC6Regs_Init(TC6_t *pInst, void *pTag, const uint8_t mac[6], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough, bool enableTimestamp);
 
 /** \brief Checks internal timers and trigger corresponding actions
  *  \note Must be called cyclic (slow delay is fine (< 1 second))
@@ -127,6 +128,20 @@ bool TC6Regs_SetPlca(TC6_t *pInst, bool plcaEnable, uint8_t nodeId, uint8_t node
  *  \return 0, in case of error. Otherwise, Chip Revision.
  */
 uint8_t TC6Regs_GetChipRevision(TC6_t *pInst);
+
+/** \brief Returns whether the attached MAC-PHY supports hardware TX/RX frame timestamping.
+ *  \param pInst - The pointer returned by TC6_Init.
+ *  \return true, if the MAC-PHY is timestamp-capable and TC6Regs_Init() was called with enableTimestamp = true.
+ */
+bool TC6Regs_GetTimestampSupported(TC6_t *pInst);
+
+/** \brief Reads a captured TX timestamp for the given timestamp-capture slot (TSC 1..3).
+ *  \param pInst - The pointer returned by TC6_Init.
+ *  \param tsc - The timestamp-capture slot (1, 2 or 3), matching the tsc argument given at send time.
+ *  \param pTimestamp - Out: the composed 64-bit timestamp (32-bit seconds, 32-bit nanoseconds), valid only if this function returns true.
+ *  \return true, if the timestamp was read successfully. false, on register-access failure or invalid arguments.
+ */
+bool TC6Regs_ReadTxTimestamp(TC6_t *pInst, uint8_t tsc, uint64_t *pTimestamp);
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 /*                   Implementation of TC6 Callback                     */

--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -70,6 +70,19 @@ Microchip or any third party.
 
 #define REG_TTSCA_HIGH      (0x00000010u) /* TTSCA_HIGH, TTSCA_LOW, TTSCB_HIGH, TTSCB_LOW, TTSCC_HIGH, TTSCC_LOW */
 
+/* PTP Hardware Clock (PHC / 1588 timer), MMS1. */
+#define REG_MAC_TSH         (0x00010070u) /* 1588 timer seconds HIGH (upper 32 bits) */
+#define REG_MAC_TSL         (0x00010074u) /* 1588 timer seconds LOW  (lower 32 bits) */
+#define REG_MAC_TN          (0x00010075u) /* 1588 timer NANOSECONDS (write commits time) */
+
+/* 1PPS output pin config, MMS10. */
+#define REG_PADCTRL         (0x000A0088u)
+#define PADCTRL_A4SEL_MASK  (0x00000300u) /* DIOA4 function select field, bits[9:8] */
+#define PADCTRL_A4SEL_1PPS  (0x00000100u) /* DIOA4 = 1PPS output (selector 1 << 8) */
+#define REG_PPSCTL          (0x000A0239u)
+#define PPSCTL_PPSEN        (0x00000001u) /* W1S: start 1PPS generation */
+#define PPSCTL_PPSPW_1280NS (0x00000004u) /* pulse width = 640*(1+1) = 1280 ns */
+
 typedef struct
 {
     uint8_t mac[6];
@@ -494,6 +507,19 @@ static void DoInitialization(TC6Reg_t *pReg)
             if (RetryRead(pReg->pTC6, REG_IMASK0, &value, TC6_REGS_CONTROL_PROTECTION)) {
                 (void)RetryWrite(pReg->pTC6, REG_IMASK0, value & ~IMASK0_TTSCA_MASK, TC6_REGS_CONTROL_PROTECTION);
             }
+        }
+        /* Seed the PHC (1588 timer) with the configured epoch before enabling data.
+           TSH=seconds high, TSL=seconds low, TN=nanoseconds (the TN write commits the new time). */
+        (void)RetryWrite(pReg->pTC6, REG_MAC_TSH, (uint32_t)((uint64_t)TC6Regs_PTP_EPOCH_SEC >> 32), TC6_REGS_CONTROL_PROTECTION);
+        (void)RetryWrite(pReg->pTC6, REG_MAC_TSL, (uint32_t)((uint64_t)TC6Regs_PTP_EPOCH_SEC & 0xFFFFFFFFu), TC6_REGS_CONTROL_PROTECTION);
+        (void)RetryWrite(pReg->pTC6, REG_MAC_TN, 0x00000000u, TC6_REGS_CONTROL_PROTECTION);
+        if (pReg->initialized && pReg->enableTimestamp && pReg->tsCapable) {
+            /* Route DIOA4 to the 1PPS output and enable a 1280ns pulse (derived from the seeded PHC).
+               Kept gated so boards that do not enable timestamping leave DIOA4 untouched. */
+            if (RetryRead(pReg->pTC6, REG_PADCTRL, &value, TC6_REGS_CONTROL_PROTECTION)) {
+                (void)RetryWrite(pReg->pTC6, REG_PADCTRL, (value & ~PADCTRL_A4SEL_MASK) | PADCTRL_A4SEL_1PPS, TC6_REGS_CONTROL_PROTECTION);
+            }
+            (void)RetryWrite(pReg->pTC6, REG_PPSCTL, (PPSCTL_PPSEN | PPSCTL_PPSPW_1280NS), TC6_REGS_CONTROL_PROTECTION);
         }
         (void)RetryWrite(pReg->pTC6, 0x00010000 /* NETWORK_CONTROL */, 0xCu, TC6_REGS_CONTROL_PROTECTION);
         if (pReg->initialized) {

--- a/libtc6/src/tc6-regs.c
+++ b/libtc6/src/tc6-regs.c
@@ -57,6 +57,19 @@ Microchip or any third party.
 /*                      DEFINES AND LOCAL VARIABLES                     */
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 
+/* Hardware TX/RX timestamping (OPEN Alliance TC6 frame timestamping) */
+#define REG_STDCAP          (0x00000002u)
+#define STDCAP_FTSE_MASK    (1u << 6u)  /* Frame timestamp capability */
+
+#define REG_CONFIG0         (0x00000004u)
+#define CONFIG0_FTSE_MASK   (1u << 7u)  /* Frame Timestamp Enable */
+#define CONFIG0_FTSS_MASK   (1u << 6u)  /* Frame Timestamp Select: 1 = 64 Bit */
+
+#define REG_IMASK0          (0x0000000Cu)
+#define IMASK0_TTSCA_MASK   (1u << 8u)  /* TX Timestamp Capture A interrupt mask */
+
+#define REG_TTSCA_HIGH      (0x00000010u) /* TTSCA_HIGH, TTSCA_LOW, TTSCB_HIGH, TTSCB_LOW, TTSCC_HIGH, TTSCC_LOW */
+
 typedef struct
 {
     uint8_t mac[6];
@@ -75,6 +88,8 @@ typedef struct
     bool promiscuous;
     bool txCutThrough;
     bool rxCutThrough;
+    bool enableTimestamp;
+    bool tsCapable;
 } TC6Reg_t;
 
 static TC6Reg_t m_reg[TC6_MAX_INSTANCES] = { 0 };
@@ -96,7 +111,7 @@ static bool RetryWrite(TC6_t *pInst, uint32_t addr, uint32_t value, bool secure)
 /*                         PUBLIC FUNCTIONS                             */
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 
-bool TC6Regs_Init(TC6_t *pTC6, void *pTag, const uint8_t mac[6], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough)
+bool TC6Regs_Init(TC6_t *pTC6, void *pTag, const uint8_t mac[6], bool enablePlca, uint8_t nodeId, uint8_t nodeCount, uint8_t burstCount, uint8_t burstTimer, bool promiscuous, bool txCutThrough, bool rxCutThrough, bool enableTimestamp)
 {
     TC6Reg_t *pReg = GetContext(pTC6);
     if (NULL != pReg) {
@@ -109,6 +124,7 @@ bool TC6Regs_Init(TC6_t *pTC6, void *pTag, const uint8_t mac[6], bool enablePlca
         pReg->promiscuous = promiscuous;
         pReg->txCutThrough = txCutThrough;
         pReg->rxCutThrough = rxCutThrough;
+        pReg->enableTimestamp = enableTimestamp;
         (void)memcpy(pReg->mac, mac, 6);
         DoInitialization(pReg);
     }
@@ -178,6 +194,33 @@ uint8_t TC6Regs_GetChipRevision(TC6_t *pTC6)
         chipRev = pReg->chipRev;
     }
     return chipRev;
+}
+
+bool TC6Regs_GetTimestampSupported(TC6_t *pTC6)
+{
+    bool supported = false;
+    TC6Reg_t *pReg = GetContext(pTC6);
+    if (NULL != pReg) {
+        supported = pReg->tsCapable;
+    }
+    return supported;
+}
+
+bool TC6Regs_ReadTxTimestamp(TC6_t *pTC6, uint8_t tsc, uint64_t *pTimestamp)
+{
+    bool success = false;
+    TC6Reg_t *pReg = GetContext(pTC6);
+    if ((NULL != pReg) && (NULL != pTimestamp) && (tsc >= 1u) && (tsc <= 3u)) {
+        uint32_t addr = REG_TTSCA_HIGH + (uint32_t)(2u * (uint32_t)(tsc - 1u));
+        uint32_t high = 0u;
+        uint32_t low = 0u;
+        success = RetryRead(pTC6, addr, &high, TC6_REGS_CONTROL_PROTECTION) &&
+                  RetryRead(pTC6, addr + 1u, &low, TC6_REGS_CONTROL_PROTECTION);
+        if (success) {
+            *pTimestamp = ((uint64_t)high << 32) | (uint64_t)low;
+        }
+    }
+    return success;
 }
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
@@ -409,6 +452,13 @@ static void DoInitialization(TC6Reg_t *pReg)
         while (pReg->initialized && (i < TC6_MEMMAP_LENGTH)) {
             i += TC6_MultipleRegisterAccess(pReg->pTC6, &TC6_MEMMAP[i], (uint16_t)(TC6_MEMMAP_LENGTH - i));
         }
+        /* Probe frame-timestamp capability. This MUST run after the MEMMAP loop:
+           the read below is protected, and the MAC-PHY only honors protected
+           control transactions once the CONFIG0 write above has enabled PROTE. */
+        pReg->tsCapable = false;
+        if (pReg->initialized && RetryRead(pReg->pTC6, REG_STDCAP, &value, TC6_REGS_CONTROL_PROTECTION)) {
+            pReg->tsCapable = (0u != (value & STDCAP_FTSE_MASK));
+        }
         /* MAC address setting */
         regVal = ((uint32_t)pReg->mac[3] << 24) | ((uint32_t)pReg->mac[2] << 16) | ((uint32_t)pReg->mac[1] << 8) | (uint32_t)pReg->mac[0];
         (void)RetryWrite(pReg->pTC6, 0x00010024u /* SPEC_ADD2_BOTTOM */, regVal, TC6_REGS_CONTROL_PROTECTION);
@@ -435,7 +485,16 @@ static void DoInitialization(TC6Reg_t *pReg)
         if (pReg->rxCutThrough) {
             regVal |= 0x100u;
         }
-        (void)RetryWrite(pReg->pTC6, 0x00000004 /* CONFIG0 */, regVal, TC6_REGS_CONTROL_PROTECTION);
+        if (pReg->enableTimestamp && pReg->tsCapable) {
+            regVal |= (CONFIG0_FTSE_MASK | CONFIG0_FTSS_MASK);
+        }
+        (void)RetryWrite(pReg->pTC6, REG_CONFIG0 /* CONFIG0 */, regVal, TC6_REGS_CONTROL_PROTECTION);
+        if (pReg->initialized && pReg->enableTimestamp && pReg->tsCapable) {
+            /* Unmask TX Timestamp Capture A interrupt (B/C are unmasked by default) */
+            if (RetryRead(pReg->pTC6, REG_IMASK0, &value, TC6_REGS_CONTROL_PROTECTION)) {
+                (void)RetryWrite(pReg->pTC6, REG_IMASK0, value & ~IMASK0_TTSCA_MASK, TC6_REGS_CONTROL_PROTECTION);
+            }
+        }
         (void)RetryWrite(pReg->pTC6, 0x00010000 /* NETWORK_CONTROL */, 0xCu, TC6_REGS_CONTROL_PROTECTION);
         if (pReg->initialized) {
             TC6_EnableData(pReg->pTC6, true);

--- a/libtc6/src/tc6.c
+++ b/libtc6/src/tc6.c
@@ -162,6 +162,7 @@ static bool accessRegisters(TC6_t *g, MemoryOp_t op, uint32_t addr, uint32_t *va
                             bool secure, uint32_t modifyMask);
 
 static uint8_t get_parity(const uint8_t *pVal);
+static uint8_t get_bit_parity(uint32_t v);
 static void addEmptyChunks(TC6_t *g, uint16_t chunkCnt);
 static bool spiDataTransaction(TC6_t *g, uint16_t chunkCnt);
 static bool waitForTXC(TC6_t *g, uint16_t waitLen);
@@ -508,25 +509,24 @@ static void on_rx_slice(TC6_t *g, const uint8_t *pBuf, uint16_t offset, uint16_t
 {
     const uint8_t *buff = pBuf; /* Because of MISRA warning */
     uint16_t buf_len = bufLen;  /* Because of MISRA warning */
-    /* TODO: handle timestamp (RTSP) */
-    (void)rtsp;
 
     if (offset == 0u) {
         g->buf_len = 0;
         g->ts = 0;
     }
 
-    /* handle timestamp (RTSA) */
+    /* handle timestamp (RTSA), validated against the RTSP parity bit */
     /* ToDo: get timestamp according to selected timestamp length (32bit or 64bit) */
     if (rtsa && (buf_len >= 8u)) {
-        g->ts = ((uint64_t)buff[0] << 56) |
-                ((uint64_t)buff[1] << 48) |
-                ((uint64_t)buff[2] << 40) |
-                ((uint64_t)buff[3] << 32) |
-                ((uint64_t)buff[4] << 24) |
-                ((uint64_t)buff[5] << 16) |
-                ((uint64_t)buff[6] << 8)  |
-                ((uint64_t)buff[7]);
+        uint32_t tsHigh = ((uint32_t)buff[0] << 24) | ((uint32_t)buff[1] << 16) | ((uint32_t)buff[2] << 8) | (uint32_t)buff[3];
+        uint32_t tsLow  = ((uint32_t)buff[4] << 24) | ((uint32_t)buff[5] << 16) | ((uint32_t)buff[6] << 8) | (uint32_t)buff[7];
+        uint8_t parity = get_bit_parity(tsHigh) ^ get_bit_parity(tsLow);
+
+        if (parity == (uint8_t)(rtsp ? 1u : 0u)) {
+            g->ts = ((uint64_t)tsHigh << 32) | (uint64_t)tsLow;
+        } else {
+            g->ts = 0;
+        }
 
         buff = &buff[8];
         buf_len -= 8u;
@@ -598,6 +598,16 @@ static uint8_t get_parity(const uint8_t *pVal)
 #endif
 
     return val;
+}
+
+static uint8_t get_bit_parity(uint32_t v)
+{
+    v ^= v >> 16;
+    v ^= v >> 8;
+    v ^= v >> 4;
+    v ^= v >> 2;
+    v ^= v >> 1;
+    return (uint8_t)(~v & 1u); /* odd parity */
 }
 
 static void addEmptyChunks(TC6_t *g, uint16_t chunkCnt)


### PR DESCRIPTION
## Summary
- Hand-ports the hardware TX/RX frame timestamping + gPTP Automotive-profile Grand Master work from `libtc6-ptp` onto `no-queues-synchronous`, adapted to this branch's blocking (no-queue) calling convention.
- `TC6Regs_ReadTxTimestamp` and the raw-send path drop the async callback/tag args in favor of direct return values, since register/data access here is already synchronous.
- gPTP GM demo is wired up on `lwIP-SAM-E54-Curiosity`; `lwIP-SAM-E54-xplained-pro` and `noIP-SAM-E54-Curiosity` just get the new `enableTimestamp` arg threaded through (disabled) to keep compiling.

## Test plan
- [x] `libtc6.X` + `liblwip.X` + `demo.X` build clean for all three affected examples (lwIP-SAM-E54-Curiosity, lwIP-SAM-E54-xplained-pro, noIP-SAM-E54-Curiosity)
- [ ] Hardware validation of gPTP Sync/Follow_Up transmission and 1PPS output on SAM E54